### PR TITLE
Created an "official" page describing how to donate to Haskell.org.

### DIFF
--- a/community.markdown
+++ b/community.markdown
@@ -8,10 +8,6 @@ isCommunity: true
 
 Haskellers interact, talk and collaborate across several mediums and around the world. There are places to learn, to teach, to ask questions, and to find contributors and collaborators.
 
-## Supporting the Community
-
-If you would like to support the Haskell community, consider [donating to Haskell.org](../donations), the organization that maintains a significant part of the Haskell community infrastructure.
-
 ## Online Communities and Social Resources
 
 Haskellers are active on a number of online areas, but the most busy are below:
@@ -89,3 +85,7 @@ Haskell Hackathons are a long tradition, with lots of learning and social exchan
 *   [Commercial Haskell Group](http://commercialhaskell.com/)
 *   [DataHaskell: data science, machine learning, numerical computation and related](http://www.datahaskell.org/)
 *   [Haskell Art](http://lurk.org/groups/haskell-art/)
+
+## Supporting the Community
+
+If you would like to support the Haskell community, consider [donating to Haskell.org](../donations), the organization that maintains a significant part of the Haskell community infrastructure.

--- a/community.markdown
+++ b/community.markdown
@@ -8,6 +8,10 @@ isCommunity: true
 
 Haskellers interact, talk and collaborate across several mediums and around the world. There are places to learn, to teach, to ask questions, and to find contributors and collaborators.
 
+## Supporting the Community
+
+If you would like to support the Haskell community, consider [donating to Haskell.org](../donations), the organization that maintains a significant part of the Haskell community infrastructure.
+
 ## Online Communities and Social Resources
 
 Haskellers are active on a number of online areas, but the most busy are below:

--- a/donations.markdown
+++ b/donations.markdown
@@ -1,0 +1,60 @@
+---
+title: Supporting Haskell.org
+page: donations
+isDonations: true
+---
+
+# Support the Community
+
+A significant part of the Haskell community infrastructure—like Hackage, Hoogle, the GHC build infrastructure and this website—runs on donations from the Haskell community. If you would like to support these efforts, you have several options for donating:
+
+  * PayPal
+  
+      <a rel="nofollow" class="external text" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=TED2EBG653TAN"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" alt="btn_donate_LG.gif"></a>
+  
+  * Checks payable to Haskell.org, Inc. mailed to:
+  
+    > Haskell.org, Inc. c/o Ryan Trinkle, Treasurer
+    >
+    > P.O. Box 1206
+    >
+    > New York, NY 10159-1206
+  
+  * [Amazon Smile][smile] which will donate 0.5% of your Amazon purchases to Haskell.org
+  
+  * Donations through employers via Benevity using the unique ID 475236502
+
+Haskell.org is a 501(c)(3) non-profit, so donations may be tax-deductible in your jurisdiction.
+
+[smile]: Amazon Smile
+
+### About Haskell.org
+
+Haskell.org, Inc. is a non-profit registered in New York, dedicated to promoting educational and scientific progress around the Haskell programming language. The organization supports the open source Haskell community, running a number of services:
+
+  * the [haskell.org] website
+  * [Hackage], Haskell's largest open package repository
+  * [GHC] pages and release infrastructure
+  * [Haskell Wiki][wiki]
+  * [mailing lists][mailing]
+  * [Discourse][discourse]
+  * [Hoogle], a type-aware Haskell search engine
+  
+Haskell.org also organizes Haskell's participation in the [Google Summer of Code program][summer].
+
+#### Contact
+
+Haskell.org is overseen by the [Haskell.org Committee][committee].
+
+If you have any questions or would like to discuss larger-scale donations or sponsorships, please contact the Committee at [committee@haskell.org][committee-email].
+
+[haskell.org]: https://haskell.org
+[Hackage]: https://hackage.haskell.org/
+[GHC]: https://www.haskell.org/ghc/
+[wiki]: https://wiki.haskell.org/Haskell
+[mailing]: https://www.haskell.org/mailing-lists/
+[discourse]: https://discourse.haskell.org
+[Hoogle]: https://hoogle.haskell.org/
+[summer]: https://summer.haskell.org/
+[committee]: https://wiki.haskell.org/Haskell.org_committee
+[committee-email]: mailto:committee@haskell.org

--- a/donations.markdown
+++ b/donations.markdown
@@ -6,7 +6,7 @@ isDonations: true
 
 # Support the Community
 
-A significant part of the Haskell community infrastructure—like Hackage, Hoogle, the GHC build infrastructure and this website—runs on donations from the Haskell community. If you would like to support these efforts, you have several options for donating:
+A significant part of the Haskell community infrastructure—like Hackage, Hoogle, the GHC build infrastructure and this website—runs on monetary and in-kind donations from the Haskell community. If you would like to support these efforts, you have several options for donating:
 
   * PayPal
   


### PR DESCRIPTION
[Axman6 on Reddit][reddit] suggested that we should have a more official-looking donation page rather than using the Wiki, which seems like a great idea. 

This PR creates a donation page with text based on [my request for donations][request] and [the old donations Wiki page][wiki-page]. It also adds a short blurb and link to the donations page from the Community page.

The biggest practical change compared to the Wiki page is that I did not list the option to donate through SPI—as far as I can tell, there is no reason for us to funnel people there over PayPal and checks directly to Haskell. I'm happy to add that note back in if there are compelling reasons for it!

[reddit]: https://www.reddit.com/r/haskell/comments/ef9elt/supporting_haskellorg/fbzv2pe/
[request]: https://www.reddit.com/r/haskell/comments/ef9elt/supporting_haskellorg/
[wiki-page]: https://wiki.haskell.org/Donate_to_Haskell.org