### PR TITLE
Made links easier to distinguish by giving them a dotted underline.

### DIFF
--- a/css/hl.css
+++ b/css/hl.css
@@ -270,7 +270,7 @@ textarea {
 
 a {
   color: #9E358F;
-  text-decoration: none; }
+  text-decoration: underline dotted; }
   a:hover, a:focus {
     color: #65225b;
     text-decoration: underline; }
@@ -656,7 +656,7 @@ samp {
 code {
   padding: 2px 4px;
   font-size: 90%;
-  color: #9E358F;
+  color: #333;
   background-color: #ebe4f3;
   border-radius: 4px; }
 


### PR DESCRIPTION
I was helping somebody install Haskell and they had trouble identifying links from body text. Being able to easily distinguish links from text is both a usability and an accessibility consideration, so we should do something to make this clearer.

Based on the WCAG guidelines on [link color], we have two options: 

  * Add a non-color way to distinguish links (ie an underline).
  * Ensure the link color has a 3:1 contrast ratio with the body text color¹.

With this in mind, if we wanted to keep links defined by color only, we would need a color that:

  * Has a 3:1 contrast ratio with our text color (#333)
  * Has a 4.5:1 contrast ratio with our background color (white)
  * Matches the overall color scheme of the site (purple)

I spent some time trying to find a color like this, but couldn't find one that worked well. If people have suggestions for a shade of purple that works well, I'd love to hear them.

Instead of finding a different color, we could add an underline to the links. We could do a normal underline:

![link-underline](https://user-images.githubusercontent.com/624310/80320405-12199a00-87cb-11ea-9a61-e690cd40d24e.png)

or a dotted underline:

![dotted-link-underline](https://user-images.githubusercontent.com/624310/80320407-12199a00-87cb-11ea-8c21-9b5e93e87bb5.png)

I personally think the dotted underline does a better job fitting in with the rest of the design, so that's the change I included in this PR.

A related problem is that inline code (like `slack` in the screenshots above) has the same color as links, which is confusing. To distinguish links from code, I also changed the inline code color to be the same as the text color—inline code is still easy to distinguish with a different background color and a monospace font.

Combining both of these changes, here's what text with inline links and code will look like after this PR:

![links-final-version](https://user-images.githubusercontent.com/624310/80320404-11810380-87cb-11ea-9dba-0395900097ad.png)

## footnotes

¹ This also requires a non-color confirmation when hovering over the link or selecting it with the keyboard, which we already do with an underline.

[link color]: https://www.w3.org/TR/WCAG20-TECHS/G183.html

