### PR TITLE
Explicitly set LOCALE_ARCHIVE and LC_ALL inside nix-shell.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,8 @@ let
         ];
       });
     }).overrideAttrs (old: {
+      LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+      LC_ALL = "en_US.UTF-8";
       shellHook = ''
         alias buildAndWatch="cabal configure && cabal build && ./dist/build/site/site clean && ./dist/build/site/site watch"
         echo ""

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
       });
     }).overrideAttrs (old: {
       LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
-      LC_ALL = "en_US.UTF-8";
+      LC_ALL = "C.UTF-8";
       shellHook = ''
         alias buildAndWatch="cabal configure && cabal build && cabal exec site -- clean && cabal exec site -- watch"
         echo ""
@@ -57,7 +57,7 @@ let
       ] ./.;
     buildInputs = [ builder pkgs.linkchecker ];
     LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
-    LC_ALL = "en_US.UTF-8";
+    LC_ALL = "C.UTF-8";
     installPhase = ''
       echo ""
       echo "  Building static site..."


### PR DESCRIPTION
With this change, I was able to run `buildAndWatch` from a Nix shell without running into Unicode errors (see #29 for details).