### PR TITLE
Added the license field to the .cabal file.

### DIFF
--- a/haskell-org.cabal
+++ b/haskell-org.cabal
@@ -2,6 +2,8 @@ name:               haskell-org
 version:            0.1.0.0
 build-type:         Simple
 cabal-version:      >= 1.10
+license:            BSD3
+license-file:       LICENSE
 
 executable site
   main-is:          site.hs


### PR DESCRIPTION
This makes the licensing of the package clear and ensures it can be used without globally configuring `allowUnfree = true` in Nix.