### PR TITLE
Bumped default Nixpkgs to a rev from 20.03 and GHC to 8.8.3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# Hakyll
 _site
 _cache
+
+# Haskell
+cabal.project.local
 dist
+dist-newstyle
+
+# Nix
 result*

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
-{ compiler ? "ghc843"
-, rev      ? "9f88b3cbeae8bc87294807ba6ce9252f9bb31ee0"
+{ compiler ? "ghc883"
+, rev      ? "d4226e3a4b5fcf988027147164e86665d382bbfa" # from Nix 20.03 release
 , pkgs     ?
     import (builtins.fetchTarball {
       url    = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
       });
     }).overrideAttrs (old: {
       shellHook = ''
-        alias buildAndWatch="cabal configure && cabal build && ./dist/build/site/site clean && ./dist/build/site/site watch"
+        alias buildAndWatch="cabal configure && cabal build && cabal exec site -- clean && cabal exec site -- watch"
         echo ""
         echo "  Haskell.org Dev Shell"
         echo "    \`buildAndWatch\` to serve the site, and rebuild when files change."

--- a/haskell-org.cabal
+++ b/haskell-org.cabal
@@ -6,7 +6,7 @@ cabal-version:      >= 1.10
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll == 4.12.*
+                  , hakyll == 4.13.*
                   , time
                   , filepath
   ghc-options:      -threaded

--- a/haskell-org.cabal
+++ b/haskell-org.cabal
@@ -6,7 +6,7 @@ cabal-version:      >= 1.10
 executable site
   main-is:          site.hs
   build-depends:    base == 4.*
-                  , hakyll == 4.13.*
+                  , hakyll >=4.12 && <4.14
                   , time
                   , filepath
   ghc-options:      -threaded


### PR DESCRIPTION
This ensures we're using a more recent GHC release and generally more recent packages. Apart from keeping us up to date, this should also let Nix fetch more packages from the public binary caches, saving on build time.

This required bumping the Hakyll requirement in the .cabal file to `4.13.*`.

The site still builds correctly with all of these changes.