### PR TITLE
Page describing Haskell.org and the Haskell.org committee

### DIFF
--- a/donations.markdown
+++ b/donations.markdown
@@ -56,5 +56,5 @@ If you have any questions or would like to discuss larger-scale donations or spo
 [discourse]: https://discourse.haskell.org
 [Hoogle]: https://hoogle.haskell.org/
 [summer]: https://summer.haskell.org/
-[committee]: https://wiki.haskell.org/Haskell.org_committee
+[committee]: haskell-org-committee
 [committee-email]: mailto:committee@haskell.org

--- a/haskell-org-committee.markdown
+++ b/haskell-org-committee.markdown
@@ -1,0 +1,59 @@
+---
+title: Haskell.org Committee
+page: haskell-org-committee
+---
+
+# Haskell.org
+
+Haskell.org is a 510(c)(3) non-profit organization that oversees the Haskell.org website and a number of other services for the Haskell community:
+
+  * [Hackage], Haskell's largest open package repository
+  * [GHC] pages and release infrastructure
+  * [Haskell Wiki][wiki]
+  * [mailing lists][mailing]
+  * [Discourse][discourse]
+  * [Hoogle], a type-aware Haskell search engine
+
+Haskell.org also organizes Haskell's participation in  the [Google Summer of Code program][summer].
+
+[summer]: https://summer.haskell.org/
+[wiki]: https://wiki.haskell.org/Haskell
+[mailing]: https://www.haskell.org/mailing-lists/
+[discourse]: https://discourse.haskell.org
+[Hoogle]: https://hoogle.haskell.org/
+[Hackage]: https://hackage.haskell.org/
+[GHC]: https://www.haskell.org/ghc/
+
+## Haskell.org Committee
+
+The Haskell.org Committee serves as the board of directors for Haskell.org. Its responsibilities include:
+
+  * setting the policy for [haskell.org] domain and subdomains
+  * setting policy for servers owned or financed by Haskell.org
+  * overseeing Haskell.org donations and funds
+
+### Committee Membership
+
+The committee consists of 7 members serving 3-year terms. The current members are:
+
+  * Ryan Trinkle (term ends 2020)
+  * Tikhon Jelvis (term ends 2020)
+  * George Wilson (term ends 2020)
+  * Emily Pillmore (term ends 2021)
+  * Jasper Van der Jeugt (Chair) (term ends 2022)
+  * Rebecca Skinner (term ends 2022)
+  * Alexandre Garcia de Oliveira (term ends 2022)
+
+At the end of each year—or if a member steps down before their term is over—the committee holds an open call for new members, encouraging self-nominations. Committee members whose terms are over are eligible for renomination.
+
+After nominations have been solicited, the current committee—including any outgoing members—selects new members with a simple majority vote.
+
+### Contact
+
+  * [committee@haskell.org][email]: directly email the committee
+  * [haskell-community mailing list][list]: public discussions about the committee and Haskell community infrastructure
+  * [GitHub][github]: issues, suggestions and pull requests for the website
+
+[email]: mailto:committeee@haskell.org
+[list]: https://mail.haskell.org/cgi-bin/mailman/listinfo/haskell-community
+[github]: https://github.com/haskell-infra/www.haskell.org/

--- a/haskell-org-committee.markdown
+++ b/haskell-org-committee.markdown
@@ -5,7 +5,7 @@ page: haskell-org-committee
 
 # Haskell.org
 
-Haskell.org is a 510(c)(3) non-profit organization that oversees the Haskell.org website and a number of other services for the Haskell community:
+Haskell.org is a 501(c)(3) non-profit organization that oversees the Haskell.org website and a number of other services for the Haskell community:
 
   * [Hackage], Haskell's largest open package repository
   * [GHC] pages and release infrastructure

--- a/index.html
+++ b/index.html
@@ -479,10 +479,11 @@ isHome: true
    <div class=" container ">
       <div class=" row ">
          <div class=" span6 col-sm-6">
-            <br>
-            <h2>Psst! Looking for the wiki?</h2>
+            <h3>Haskell.org</h3>
+            Hosted and managed by <a href="haskell-org-committee">Haskell.org</a>, a 501(c)(3) non-profit.
+
+            <h3>Psst! Looking for the wiki?</h3>
             <p>This is the new Haskell home page! The wiki has moved to <a href="https://wiki.haskell.org">wiki.haskell.org.</a></p>
-            <br>
          </div>
       </div>
    </div>


### PR DESCRIPTION
This adds an "official" page describing the Haskell.org non-profit and the Haskell.org committee. The content is based on the [Haskell.org committee wiki page][wiki], edited a bit for focus and clarity.

Over time, I expect this page will cover more details about how the committee operates and makes decisions—this is the first step to making the committee's activities and structure more transparent to the community.

[wiki]: https://wiki.haskell.org/Haskell.org_committee