### PR TITLE
Extend committee page

### DIFF
--- a/community.markdown
+++ b/community.markdown
@@ -45,6 +45,16 @@ There are a number of Haskell Users groups where haskellers meet to learn and co
 *   [Seattle Area Haskell Users' Group (SeaHUG)](http://seattlehaskell.org/)
 *   [More Haskell meetups at meetup.com](http://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity)
 
+## Committees
+
+Haskell infrastructure is mostly maintained by committees and groups volunteers.  Here are some of the committees involved in keeping things running:
+
+*   [Core Libraries Committee](https://wiki.haskell.org/Core_Libraries_Committee)
+*   [GHC Steering Committee](https://github.com/ghc-proposals/ghc-proposals)
+*   [Hackage trustees](https://wiki.haskell.org/Hackage_trustees)
+*   [Haskell.org committee](/haskell-org-committee)
+*   [Stackage maintainers](https://docs.haskellstack.org/en/stable/maintainers/team_process/)
+
 ## Conferences and Events
 
 There are a number of conferences and events featuring Haskell, some focusing on the academic side of things, and some on the commercial or hobbyist side. Here are just a few:

--- a/community.markdown
+++ b/community.markdown
@@ -47,7 +47,7 @@ There are a number of Haskell Users groups where haskellers meet to learn and co
 
 ## Committees
 
-Haskell infrastructure is mostly maintained by committees and groups volunteers.  Here are some of the committees involved in keeping things running:
+Haskell infrastructure is mostly maintained by committees and groups of volunteers.  Here are some of the committees involved in keeping things running:
 
 *   [Core Libraries Committee](https://wiki.haskell.org/Core_Libraries_Committee)
 *   [GHC Steering Committee](https://github.com/ghc-proposals/ghc-proposals)

--- a/haskell-org-committee.markdown
+++ b/haskell-org-committee.markdown
@@ -48,7 +48,7 @@ In November of each year—or if a member steps down before their term is over�
 
 Committee members do not need to be deep technical Haskell experts.  Instead we look for enthusiasm towards improving the Haskell community.  We aim to represent the different facets of the community.  We aim to be diverse in terms of industry or research, and in terms of gender, race and location.
 
-After nominations have been solicited, in the current committee—including any outgoing members—selects new members with a simple majority vote.
+After nominations have been solicited, the current committee—including any outgoing members—selects new members with a simple majority vote.
 
 Due this has never occurred in the past, Committee members can also be removed by majority vote.
 

--- a/haskell-org-committee.markdown
+++ b/haskell-org-committee.markdown
@@ -44,9 +44,17 @@ The committee consists of 7 members serving 3-year terms. The current members ar
   * Rebecca Skinner (term ends 2022)
   * Alexandre Garcia de Oliveira (term ends 2022)
 
-At the end of each year—or if a member steps down before their term is over—the committee holds an open call for new members, encouraging self-nominations. Committee members whose terms are over are eligible for renomination.
+In November of each year—or if a member steps down before their term is over—the committee holds an open call for new members, encouraging self-nominations. Committee members whose terms are over are eligible for renomination.
 
-After nominations have been solicited, the current committee—including any outgoing members—selects new members with a simple majority vote.
+Committee members do not need to be deep technical Haskell experts.  Instead we look for enthusiasm towards improving the Haskell community.  We aim to represent the different facets of the community.  We aim to be diverse in terms of industry or research, and in terms of gender, race and location.
+
+After nominations have been solicited, in the current committee—including any outgoing members—selects new members with a simple majority vote.
+
+Due this has never occurred in the past, Committee members can also be removed by majority vote.
+
+### Process
+
+The Committee uses the [haskell-community][list] for public discussion.  Proposals and meeting notes are stored in a [public repository][repo].
 
 ### Contact
 
@@ -57,3 +65,4 @@ After nominations have been solicited, the current committee—including any out
 [email]: mailto:committeee@haskell.org
 [list]: https://mail.haskell.org/cgi-bin/mailman/listinfo/haskell-community
 [github]: https://github.com/haskell-infra/www.haskell.org/
+[repo]: https://github.com/haskell-org/committee

--- a/haskell-org-committee.markdown
+++ b/haskell-org-committee.markdown
@@ -50,7 +50,7 @@ Committee members do not need to be deep technical Haskell experts.  Instead we 
 
 After nominations have been solicited, the current committee—including any outgoing members—selects new members with a simple majority vote.
 
-Due this has never occurred in the past, Committee members can also be removed by majority vote.
+While this has never occurred in the past, Committee members can also be removed by majority vote.
 
 ### Process
 


### PR DESCRIPTION
- Add some committees to the community page
- Extend the haskell.org committee page with more details on how we look for members