### PR TITLE
PR policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the website for www.haskell.org built as a hakyll static site, which builds both as a nix derivation and a standalone cabal project. Issues with the site can be raised in this repository, and PRs can be made to change content. More general administrative issues with the site or related haskell.org infrastructure are better raised directly with the admin team on the #haskell-infrastructure channel on freenode, or at the admin@[LANGUAGE].org email address.
 
+* [The PR policy of this repository](https://github.com/haskell-org/committee/blob/main/proposals/0003-pr-process.md)
+
 ### Subsites
 
 Not all subsites of www.haskell.org are built from this repository.


### PR DESCRIPTION
I think it would be helpful to have the two-reviewers policy (as [explained by @TikhonJelvis](https://github.com/haskell-infra/www.haskell.org/pull/48#issuecomment-743793498)) clearly stated. This PR builds on https://github.com/haskell-infra/www.haskell.org/pull/50. If it didn't it would lead to a merge conflict.