### PR TITLE
Remove obsolete IO actions from sandbox suggestions

### DIFF
--- a/js/tryhaskell.pages.js
+++ b/js/tryhaskell.pages.js
@@ -35,9 +35,7 @@ tryhaskell.pages.list =
          '<p>' +
          '<code title="Click me to insert &quot;23 * 36&quot; into the console." style="cursor: pointer;">23 * 36</code> or <code title="Click me to insert &quot;reverse ' +
          '&quot;hello&quot;&quot; into the console." style="cursor: pointer;">reverse ' +
-         '"hello"</code> or <code title="Click me to insert &quot;map (+1) [1,2,3]&quot; into the console." style="cursor: pointer;">foldr (:) [] [1,2,3]</code> or <code title="Click me to insert." style="cursor: pointer;">do line <- getLine; putStrLn line</code> or <code>readFile "/welcome"</code>' +
-         '</p>' +
-         '<p><a href="https://hackage.haskell.org/package/pure-io-0.2.0/docs/PureIO.html#g:2">These</a> IO actions are supported in this sandbox.</p>' +
+         '"hello"</code> or <code title="Click me to insert &quot;map (+1) [1,2,3]&quot; into the console." style="cursor: pointer;">foldr (:) [] [1,2,3]</code>' +
          '</p>' +
          '</div>' +
          '</div>'


### PR DESCRIPTION
This should fix #55 .
Made it similar to https://tryhaskell.org/ (which is a backend for the sandbox).