### PR TITLE
haskell-org.cabal: rename site executable --> haskell-org-site

### DIFF
--- a/haskell-org.cabal
+++ b/haskell-org.cabal
@@ -5,7 +5,7 @@ cabal-version:      >= 1.10
 license:            BSD3
 license-file:       LICENSE
 
-executable site
+executable haskell-org-site
   main-is:          site.hs
   build-depends:    base == 4.*
                   , hakyll >=4.12 && <4.14


### PR DESCRIPTION
This ensures there are no conflicts with other hakyll sites (that might create another executable called `site`).