### PR TITLE
Fix buildAndWatch command in nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,7 +39,7 @@ let
       LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
       LC_ALL = "C.UTF-8";
       shellHook = ''
-        alias buildAndWatch="cabal configure && cabal build && cabal exec site -- clean && cabal exec site -- watch"
+        alias buildAndWatch="cabal configure && cabal build && cabal exec haskell-org-site -- clean && cabal exec haskell-org-site -- watch"
         echo ""
         echo "  Haskell.org Dev Shell"
         echo "    \`buildAndWatch\` to serve the site, and rebuild when files change."
@@ -62,7 +62,7 @@ let
       echo ""
       echo "  Building static site..."
       echo ""
-      site build
+      haskell-org-site build
       echo ""
       echo "  Checking for bad links..."
       echo ""


### PR DESCRIPTION
In #63 we renamed the executable from `site` to `haskell-org-site` to avoid collisions with other projects. However, we didn't update the name in the `default.nix` file, which broke the `buildAndWatch` command in the Nix shell.

This PR fixes that problem.