### PR TITLE
donations: copy content from https://wiki.haskell.org/Donate_to_Haskell.org

### DIFF
--- a/donations.markdown
+++ b/donations.markdown
@@ -38,11 +38,6 @@ To make a concrete contribution to the maintenance and development of Haskell co
 Some particular aspects of the work of Haskell.org include producing and maintaining material regarding the Haskell language on haskell.org and other associated websites; hosting and maintaining shared assets and infrastructure for the benefit of the Haskell community; coordinating educational activities including mentorship programs; and potentially organizing event regarding the Haskell language.
 
 Responsibility for the activities of haskell.org lies with the haskell.org committee, which serves as its board of directors.
-How to donate
-
-Contact
-
-Arrangements regarding larger-scale donations or sponsorships (including official recognition) can be discussed with the committee, reachable via committee [AT] haskell.org.
 
 ### About Haskell.org
 
@@ -64,7 +59,7 @@ Haskell.org also organizes Haskell's participation in the [Google Summer of Code
 
 Haskell.org is overseen by the [Haskell.org Committee][committee].
 
-If you have any questions or would like to discuss larger-scale donations or sponsorships, please contact the Committee at [committee@haskell.org][committee-email].
+If you have any questions or would like to discuss sponsorships, official recognition, or larger-scale donations or sponsorships, please contact the Committee at [committee@haskell.org][committee-email].
 
 [haskell.org]: https://haskell.org
 [Hackage]: https://hackage.haskell.org/

--- a/donations.markdown
+++ b/donations.markdown
@@ -8,7 +8,7 @@ isDonations: true
 
 A significant part of the Haskell community infrastructure—like Hackage, Hoogle, the GHC build infrastructure and this website—runs on monetary and in-kind donations from the Haskell community. If you would like to support these efforts, you have several options for donating:
 
-  * PayPal
+  * PayPal (preferred)
   
       <a rel="nofollow" class="external text" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=TED2EBG653TAN"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" alt="btn_donate_LG.gif"></a>
   
@@ -24,12 +24,29 @@ A significant part of the Haskell community infrastructure—like Hackage, Hoogl
   
   * Donations through employers via Benevity using the unique ID 475236502
 
+  * Through SPI - Haskell.org is an associated project of Software in the Public Interest, also a registered non-profit organization under the laws of New York State. Donations via the SPI can be made online via credit card, invoice, PO or eCheck through clickandpledge.com or by mailing an earmarked check directly to SPI: http://www.spi-inc.org/donations/. Recurring donations can be set up in addition to one-time donations. Note that donations through SPI require more overhead from the Committee, so we encourage you to use the other ways of donating.
+
 Haskell.org is a 501(c)(3) non-profit, so donations may be tax-deductible in your jurisdiction.
 
 [smile]: https://smile.amazon.com
 [smile-details]: https://smile.amazon.com/about
 
+### Why should I donate?
+
+To make a concrete contribution to the maintenance and development of Haskell community infrastructure, including the hosting and deployment of community resources, from Hackage to Hoogle and beyond, the best thing to do is find a way to volunteer and get involved! However, donations are also very welcome and needed. We will find ways to put donations to good use, be they for infrastructure administration, new hardware, or continued work on software infrastructure projects.
+
+Some particular aspects of the work of Haskell.org include producing and maintaining material regarding the Haskell language on haskell.org and other associated websites; hosting and maintaining shared assets and infrastructure for the benefit of the Haskell community; coordinating educational activities including mentorship programs; and potentially organizing event regarding the Haskell language.
+
+Responsibility for the activities of haskell.org lies with the haskell.org committee, which serves as its board of directors.
+How to donate
+
+Contact
+
+Arrangements regarding larger-scale donations or sponsorships (including official recognition) can be discussed with the committee, reachable via committee [AT] haskell.org.
+
 ### About Haskell.org
+
+Haskell.org is the organization representing the Open Source Haskell community, and is incorporated in the state of New York. Its purpose is to promote educational and scientific progress relating to the Haskell programming language and related technologies. As a whole it seeks to service the open source Haskell community. Haskell.org activities are directed towards charitable purposes, and are in compliance with section 501(c)(3) of the U.S. federal income tax code. Haskell.org has nonprofit tax-exempt status under this section.
 
 Haskell.org, Inc. is a non-profit registered in New York, dedicated to promoting educational and scientific progress around the Haskell programming language. The organization supports the open source Haskell community, running a number of services:
 


### PR DESCRIPTION
This contributes to #59, moving authoritative content from the wiki to the primary haskell.org website.

We can update with commits to clean it up, but ATM this is the content from that page, more or less as-is. 

After this is cleaned up and live, we can then update the wiki page to replace its content with a link back to this donations page on haskell.org.