### PR TITLE
README: correct 'site' to 'haskell-org-site'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ This repo provides haskell.org as a nix derivation of a hakyll built static site
 
 ### Developing
 
-Simply run `nix-shell`. This will allow you to build the `site` binary which in turn builds the static site.
+Simply run `nix-shell`. This will allow you to build the `haskell-org-site` binary which in turn builds the static site.
 You may also edit the content of the site in the shell.
 
 ### Editing
 
-You may install the site binary locally with `nix-env -f . -iA builder`. Once `site` is on your path you can edit content, and have
+You may install the `haskell-org-site` binary locally with `nix-env -f . -iA builder`. Once `haskell-org-site` is on your path you can edit content, and have
 the site served with `site watch`.
 
 ### Building
 
-To obtain the static site simply run `nix-build -A built` and the generated `result` link will contain the static site contents.
+To obtain the static `haskell-org-site` simply run `nix-build -A built` and the generated `result` link will contain the static site contents.


### PR DESCRIPTION
Back in 85befe2c555834a217fb65655e864e147bf9b5d4 the `site` executable was renamed to `haskell-org-site`. This commit updates the README to sync with that change.