### PR TITLE
site: find .markdown files 1, 2 or 3 levels down

### DIFF
--- a/site.hs
+++ b/site.hs
@@ -26,7 +26,7 @@ main = mkContext >>= \ctx -> hakyll $ do
     route idRoute
     compile $ defCompiler ctx
 
-  match ("**/*.markdown" .||. "*.markdown") $ do
+  match ("**/**/*.markdown" .||. "**/*.markdown" .||. "*.markdown") $ do
     route cleanRoute
     compile $ mdCompiler ctx
 


### PR DESCRIPTION
This commit lets the `haskell-org-site` match `.markdown` files several directory levels deep. This will support efforts to build out docs and tutorials, and as content is moved from the wiki.