### PR TITLE
Reinstate link to Haskell Platform repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Not all subsites of www.haskell.org are built from this repository.
 Some of the others are
 
 * www.haskell.org/cabal (built from [cabal-website](https://github.com/haskell/cabal-website))
+* www.haskell.org/platform (built from [haskell-platform](https://github.com/haskell/haskell-platform/tree/master/website))
 
 ### Cabal instructions
 Just run `cabal v2-build` to build or `cabal v2-run` to run, and `cabal v2-run -- build` to actually build the site.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Some of the others are
 
 * www.haskell.org/cabal (built from [cabal-website](https://github.com/haskell/cabal-website))
 * www.haskell.org/platform (built from [haskell-platform](https://github.com/haskell/haskell-platform/tree/master/website))
+* www.haskell.org/ghcup (build from [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs/-/tree/master/www)
 
 ### Cabal instructions
 Just run `cabal v2-build` to build or `cabal v2-run` to run, and `cabal v2-run -- build` to actually build the site.


### PR DESCRIPTION
... and add link to ghcup subsite

Fixes https://github.com/haskell-infra/www.haskell.org/issues/77