### PR TITLE
Create a Zip File with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,8 @@ jobs:
 
       - name: Check Links
         run: nix-shell --command 'linkchecker _site'
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: www.haskell.org
+          path: result-1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: www.haskell.org
-          path: result-1
+          path: result-1/**/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: www.haskell.org
-          path: result-*/**/*
+          path: result-*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: Build Site
-        run: nix build -f . built -o built-site
+        # we run the checks as a separate step
+        run: nix build -f . built -o built-site --arg doCheck false
 
       - name: Check Links
         run: nix-shell --command 'linkchecker built-site'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: nix build -f . built -o built-site
 
       - name: Check Links
-        run: nix-shell --command 'linkchecker site'
+        run: nix-shell --command 'linkchecker built-site'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,8 @@ jobs:
       - name: Build Executable
         run: nix-build
 
-      - name: Build Site
-        run:  result/bin/haskell-org-site build
-
       - name: Check Links
-        run: nix-shell --command 'linkchecker _site'
+        run: nix-shell --command 'linkchecker result-1'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,17 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: Build Executable
-        run: nix build && ls -la
+        run: nix build
 
       - name: Check Links
-        run: ls -la && ls -R result* && nix-shell --command 'linkchecker result-1'
+        run: nix-shell --command 'linkchecker result-1'
 
       - uses: actions/upload-artifact@v2
         with:
           name: www.haskell.org
-          path: result-*
+          path: result-*        # Uses glob pattern because
+                                # actions/upload-artifact@v2 gets
+                                # confused by symlinks otherwise
+                                #
+                                # See:
+                                # https://github.com/actions/upload-artifact/issues/92

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: Build Executable
-        run: nix build
+        run: nix-build
 
       - name: Check Links
         run: nix-shell --command 'linkchecker result-1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         run: nix build -f . built -o built-site --arg doCheck false
 
       - name: Check Links
-        run: nix-shell --command 'linkchecker built-site'
+        run: nix run --quiet nixpkgs.linkchecker -c linkchecker built-site
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v12
 
-      - name: Build Executable
+      - name: Build Site
         run: nix build -f . built -o built-site
 
       - name: Check Links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: Build Executable
-        run: nix build -f . built -o site
+        run: nix build -f . built -o built-site
 
       - name: Check Links
         run: nix-shell --command 'linkchecker site'
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: www.haskell.org
-          path: site*        # Uses glob pattern because
+          path: built-site*  # Uses glob pattern because
                              # actions/upload-artifact@v2 gets
                              # confused by symlinks otherwise
                              #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: Build Executable
-        run: nix-build
+        run: nix build && ls -la
 
       - name: Check Links
-        run: nix-shell --command 'linkchecker result-1'
+        run: ls -la && ls -R result* && nix-shell --command 'linkchecker result-1'
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,17 +15,17 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: Build Executable
-        run: nix-build
+        run: nix build -f . built -o site
 
       - name: Check Links
-        run: nix-shell --command 'linkchecker result-1'
+        run: nix-shell --command 'linkchecker site'
 
       - uses: actions/upload-artifact@v2
         with:
           name: www.haskell.org
-          path: result-*        # Uses glob pattern because
-                                # actions/upload-artifact@v2 gets
-                                # confused by symlinks otherwise
-                                #
-                                # See:
-                                # https://github.com/actions/upload-artifact/issues/92
+          path: site*        # Uses glob pattern because
+                             # actions/upload-artifact@v2 gets
+                             # confused by symlinks otherwise
+                             #
+                             # See:
+                             # https://github.com/actions/upload-artifact/issues/92

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         run: nix build -f . built -o built-site --arg doCheck false
 
       - name: Check Links
-        run: nix run --quiet nixpkgs.linkchecker -c linkchecker built-site
+        run: nix run --quiet -f . linkchecker -c linkchecker built-site
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: www.haskell.org
-          path: result-1/**/*
+          path: result-*/**/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist-newstyle
 
 # Nix
 result*
+site

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ dist-newstyle
 
 # Nix
 result*
-site
+built-site

--- a/community.markdown
+++ b/community.markdown
@@ -8,7 +8,7 @@ isCommunity: true
 
 Haskellers interact, talk and collaborate across several mediums and around the world. There are places to learn, to teach, to ask questions, and to find contributors and collaborators.
 
-[Help support the community!](/donations/)
+[Help support the community!](/donations2/)
 
 ## Online Communities and Social Resources
 

--- a/community.markdown
+++ b/community.markdown
@@ -8,7 +8,7 @@ isCommunity: true
 
 Haskellers interact, talk and collaborate across several mediums and around the world. There are places to learn, to teach, to ask questions, and to find contributors and collaborators.
 
-[Help support the community!](/donations2/)
+[Help support the community!](/donations/)
 
 ## Online Communities and Social Resources
 

--- a/default.nix
+++ b/default.nix
@@ -77,4 +77,4 @@ let
   };
 in
   if pkgs.lib.inNixShell then builder
-  else { inherit builder built; }
+  else { inherit builder built; inherit (pkgs) linkchecker; }

--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,7 @@ let
           "js/*"
           "img/*"
           ".git"
+          ".github"
         ] ./.;
       modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
         buildTools = with pkgs.haskell.packages.${compiler}; (attrs.buildTools or []) ++ [
@@ -54,6 +55,7 @@ let
       ".git"
       "*.cabal"
       "*.hs"
+      ".github"
       ] ./.;
     buildInputs = [ builder pkgs.linkchecker ];
     LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";


### PR DESCRIPTION
This PR cleans up our GitHub action definition and generates a zip file with the site contents as an artifact.

The upload-artifact@v2 action had trouble with symlinks (see [this issue][1]), so we needed to specify the path as a glob.

Next steps: automatically deploy the site if it builds and passes our checks. This will require managing SSH keys in CI.

[1]: https://github.com/actions/upload-artifact/issues/92