### PR TITLE
freenode -> libera.chat

### DIFF
--- a/irc.markdown
+++ b/irc.markdown
@@ -6,11 +6,9 @@ isCommunity: true
 
 # IRC Channels
 
-The IRC channel can be an excellent place to learn more about Haskell, and to just keep in the loop on new things in the Haskell world. Many new developments in the Haskell world first appear on the IRC channel.
+The IRC channel can be an excellent place to learn more about Haskell, and to just keep in the loop on new things in the Haskell world. Many new developments in the Haskell world first appear on the IRC channel. Haskell channels have been moving from freenode and are now mainly established on libera.chat.
 
-Point your IRC client to `chat.freenode.net` and then join the `#haskell` channel. Check the [knowledge base](https://freenode.net/kb/answer/chat) for more connection information.
-
-Alternately, you can try [http://webchat.freenode.net/](http://webchat.freenode.net/) which connects inside the browser.
+Point your IRC client to `irc.libera.chat:6697 (TLS)` and then join the `#haskell` channel. Check the [guides](https://libera.chat/guides) for more connection information.
 
 ## Logs
 

--- a/irc.markdown
+++ b/irc.markdown
@@ -6,7 +6,7 @@ isCommunity: true
 
 # IRC Channels
 
-The IRC channel can be an excellent place to learn more about Haskell, and to just keep in the loop on new things in the Haskell world. Many new developments in the Haskell world first appear on the IRC channel. Haskell channels have been moving from freenode and are now mainly established on libera.chat.
+The IRC channel can be an excellent place to learn more about Haskell, and to just keep in the loop on new things in the Haskell world. Many new developments in the Haskell world first appear on the IRC channel. Haskell channels have been moving from freenode and are now mainly established on [libera.chat](https://libera.chat).
 
 Point your IRC client to `irc.libera.chat:6697 (TLS)` and then join the `#haskell` channel. Check the [guides](https://libera.chat/guides) for more connection information.
 


### PR DESCRIPTION
given discussion on https://www.reddit.com/r/haskell/comments/nfqw0t/thoughts_on_the_state_of_the_freenode_irc_network/ and elsewhere, people have begun migrating from the haskell group of channels on freenode to libera.chat, which is where the freenode admins and ops have migrated following the hostile takeover.

This is a PR to update the haskell website accordingly. It might take a day or two for it to become evident that this is the clear direction of the community, but most trusted #haskell ops have made the shift at this point (and some are even libera volunteers directly), so by the time this PR is approved and merged, I imagine it will be obviously accurate.