### PR TITLE
Remove broken webmon.com link

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,11 +468,6 @@ isHome: true
             <p><strong><a href="https://www.dreamhost.com">DreamHost</a></strong> has teamed up to provide Haskell.org with redundant, scalable object-storage through their Dream Objects service.</p>
          </div>
       </div>
-      <div class=" row ">
-         <div class=" span6 col-sm-6">
-            <p><strong><a href="https://webmon.com">Webmon</a></strong> provides monitoring and escalation for core haskell.org infrastructure.</p>
-         </div>
-      </div>
    </div>
 </div>
 <div class="transition">


### PR DESCRIPTION
It appears this domain is no longer pointing towards a legitimate service, at least as of Feb 13th 2021:
* https://www.domainiq.com/domain?webmon.com

It might be best to remove this link from the https://www.haskell.org, at least for now.

Currently, the domain is parked on both 443 and 80:

![webmon1](https://user-images.githubusercontent.com/523628/119513196-fec85d80-bd41-11eb-9194-2a2bb8fc2bc5.png)
![webmon2](https://user-images.githubusercontent.com/523628/119513207-01c34e00-bd42-11eb-8155-0a5e8f169b14.png)

