### PR TITLE
Automatically deploy site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+# We deploy the site *only* on
+#
+# 1. A push to master, or
+# 2. A manually triggered Deploy build
+#
+# We don't want to deploy for every branch and PR of course!
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v12
+
+      # The CI Github Action also builds the site and puts it in an
+      # artifact.  However, downloading an artifact from a different
+      # workflow seems to be difficult.
+      #
+      # https://github.com/actions/download-artifact/issues/3
+      #
+      # We'll just build the whole site again here.  It only takes a
+      # couple of minutes.
+      - name: Build Site
+        # we run the checks as a separate step
+        run: nix build -f . built -o built-site --arg doCheck false
+
+      - name: Check Links
+        run: nix run --quiet -f . linkchecker -c linkchecker built-site
+
+      - name: Deploy
+        shell: bash
+        env:
+          # Create the secret with:
+          #
+          # Settings -> Secrets -> New Repository Secret ->
+          #
+          #   Name: WWW_HASKELL_ORG_SSH_KEY
+          #   Value: The text of the ssh private key
+          WWW_HASKELL_ORG_SSH_KEY: ${{ secrets.WWW_HASKELL_ORG_SSH_KEY }}
+        run: |
+          nix run --quiet -f . lftp -c sh ./deploy.sh --DEPLOY-IT-LIVE

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ You may then run the builder binary from the `result` directory:
 ```
 ./result/bin/haskell-org-site build
 ```
+
+### Deploying
+
+The site will automatically be deployed live to <http://www.haskell.org/> every time a branch is merged to `master`. Alternatively an admin for this GitHub repository can deploy the site by visiting the [Deploy workflow page](https://github.com/haskell-infra/www.haskell.org/actions/workflows/deploy.yml), clicking the "Run workflow" dropdown, choosing the branch to build and deploy, and clicking the "Run workflow" button.

--- a/default.nix
+++ b/default.nix
@@ -33,4 +33,4 @@ let
   };
 in
   if pkgs.lib.inNixShell then builder
-  else { inherit builder built; inherit (pkgs) linkchecker; }
+  else { inherit builder built; inherit (pkgs) linkchecker lftp; }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# TODO: make this with tempfile
+KEYFILE=__TEMP_INPUT_KEY_FILE
+
+echo "${WWW_HASKELL_ORG_SSH_KEY}" > "$KEYFILE"
+chmod 600 "$KEYFILE"
+
+if [ "$1" = --DEPLOY-IT-LIVE ]; then
+    DESTINATION=www
+else
+    DESTINATION=www-test
+fi
+
+# WARNING: --delete is dangerous.  Be absolutely sure you are
+# deploying to the correct directory.  Existing contents of the
+# destination directory will be removed.
+#
+# Permissions: We have to recursively set write permissions because
+# lftp isn't able to remove a file if its directory is not writeable.
+lftp --norc -c "set net:max-retries 1; set sftp:connect-program \"ssh -o StrictHostKeyChecking=no -a -x -i $KEYFILE\"; open -u www-sftp, sftp://webhost.haskell.org; chmod --recursive u+w $DESTINATION; mirror --delete --verbose --reverse --transfer-all built-site $DESTINATION"


### PR DESCRIPTION
This PR adds a Github Action to build the website and deploy it to the haskell.org server.  We deploy the site *only* on

1. A push to `master`, or
2. A manually triggered Deploy build

(We don't want to deploy for every branch and PR of course!)

I have tested this on my fork. See https://github.com/tomjaguarpaw/www.haskell.org/runs/2678438965?check_suite_focus=true for a successful (dry run) deployment.

### What we need from the Haskell infrastructure admins

- [x] Confirmation that this matches their expectations of an automated deployment script
- [x] A definitive username and directory on the remote host to be the target of the `rsync`
- [x] To authorise the `rsync` user by placing the public key on the server in the right place

### To do before merging:

- [x] Generate an SSH public/private key, get the public key on the server via @davean/Haskell infrastructure admins, get the private key into Github Actions secrets
- [x] Convince ourselves that it is safe to remove `--dry-run`

(Closes https://github.com/haskell-infra/www.haskell.org/issues/83)