### PR TITLE
Add link to Haskell Matrix Space

### DIFF
--- a/community.markdown
+++ b/community.markdown
@@ -17,6 +17,7 @@ Haskellers are active on a number of online areas, but the most busy are below:
 
 *   [The Haskell mailing lists](/mailing-lists/)
 *   [IRC (online chat)](/irc/)
+*   [Matrix (online chat)](https://matrix.to/#/#haskell-space:matrix.org)
 *   [Haskell Community Discourse](https://discourse.haskell.org)
 *   [StackOverflow](http://stackoverflow.com/questions/tagged?tagnames=haskell)
 *   [Facebook community](https://www.facebook.com/groups/programming.haskell/)

--- a/community.markdown
+++ b/community.markdown
@@ -17,7 +17,7 @@ Haskellers are active on a number of online areas, but the most busy are below:
 
 *   [The Haskell mailing lists](/mailing-lists/)
 *   [IRC (online chat)](/irc/)
-*   [Matrix (online chat)](https://matrix.to/#/#haskell-space:matrix.org)
+*   [Matrix (online chat)](https://matrix.to/#/#haskell:matrix.org)
 *   [Haskell Community Discourse](https://discourse.haskell.org)
 *   [StackOverflow](http://stackoverflow.com/questions/tagged?tagnames=haskell)
 *   [Facebook community](https://www.facebook.com/groups/programming.haskell/)


### PR DESCRIPTION
The Matrix Space includes bridges to the IRC channel like #haskell as well.

Here's a screenshot of our "room tree".

![image](https://user-images.githubusercontent.com/3998/120039691-56312c80-bfd3-11eb-930d-4202065223ed.png)
![image](https://user-images.githubusercontent.com/3998/120039712-5f21fe00-bfd3-11eb-9c6c-f9eef46c441e.png)
