### PR TITLE
refactor buildAndWatch to run outside of the nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,70 @@ Some of the others are
 * www.haskell.org/platform (built from [haskell-platform](https://github.com/haskell/haskell-platform/tree/master/website))
 * www.haskell.org/ghcup (build from [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs/-/tree/master/www)
 
-### Cabal instructions
-Just run `cabal v2-build` to build or `cabal v2-run` to run, and `cabal v2-run -- build` to actually build the site.
+### Nix
 
-### Nix instructions
+The best way to make changes to haskell.org is to use nix. You can install it
+by following the directions [on the nix downloads page](https://nixos.org/download.html).
 
-This repo provides haskell.org as a nix derivation of a hakyll built static site. The `default.nix` file returns a set with two elements
-- builder (the hakyll binary which processes source into the static site)
-- built (the static site built by the builder, and ready to serve)
+### Contributing Changes
 
-### Developing
+The easiest way to make changes is to use the `buildAndWatch` script and then
+point your web browser to [http://localhost:8000](http://localhost:8000). When
+you are finished editing or want to re-build the hakyll part of the site, you
+can stop the script by pressing `Control+c` (`C-c`).
 
-Simply run `nix-shell`. This will allow you to build the `haskell-org-site` binary which in turn builds the static site.
-You may also edit the content of the site in the shell.
+If you are only making changes to the content of the site, you can leave this
+script running and it will automatically pick up changes and re-build the site
+for you.
 
-### Editing
+If you want to change the `builder`, or if you encounter an error where your
+changes to the content aren't being picked up, need to stop the script and
+re-start it.
 
-You may install the `haskell-org-site` binary locally with `nix-env -f . -iA builder`. Once `haskell-org-site` is on your path you can edit content, and have
-the site served with `site watch`.
+Once you're satisfied with your changes, make a PR and the maintainers will try
+to review it as soon as we can.
 
-### Building
+### Working On The Builder
 
-To obtain the static `haskell-org-site` simply run `nix-build -A built` and the generated `result` link will contain the static site contents.
+The `builder` is the static site generator that turns the markdown files, CSS,
+images, and scripts into a website. It lives in the `builder`. Most of the time,
+you won't need to make changes to the builder and you can follow the
+instructions in the _Contributing Changes_ section above.
+
+If you want to make a quick change or two, you can continue to use the
+`buildAndWatch` script to rebuild changes, but for more substantial changes this
+might increase the build cycle time too much. In that case, you can test your
+changes more immediately by building with `cabal`.
+
+If you want to ensure that you are using the correct versions of all of the
+libraries, you can develop inside of a nix shell. To do that, simply type:
+
+`nix-shell` from either the project root directory or the `builder` directory.
+
+To build the builder with cabal, go into the `builder` directory and run:
+
+```
+cabal v2-build
+```
+
+### Manually Building the Site with the Builder
+
+If you want to manually build the site with the builder, you need to run the
+builder from the project root directory. You can do this by building the site
+with nix:
+
+```
+nix-build -A builder
+```
+
+Then running the builder binary from the `result` directory:
+
+```
+./result/bin/haskell-org-site build
+```
+
+Alternatively you can build with cabal and run the executable directly:
+
+```
+./builder/dist-newstyle/build/x86_64-linux/ghc-8.8.4/haskell-org-0.1.0.0/x/haskell-org-site/build/haskell-org-site/haskell-org-site build
+```

--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ Some of the others are
 * www.haskell.org/platform (built from [haskell-platform](https://github.com/haskell/haskell-platform/tree/master/website))
 * www.haskell.org/ghcup (build from [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs/-/tree/master/www)
 
-### Nix
-
-The best way to make changes to haskell.org is to use nix. You can install it
-by following the directions [on the nix downloads page](https://nixos.org/download.html).
-
 ### Contributing Changes
 
 The easiest way to make changes is to use the `buildAndWatch` script and then
@@ -43,38 +38,41 @@ instructions in the _Contributing Changes_ section above.
 
 If you want to make a quick change or two, you can continue to use the
 `buildAndWatch` script to rebuild changes, but for more substantial changes this
-might increase the build cycle time too much. In that case, you can test your
-changes more immediately by building with `cabal`.
+might increase the build cycle time too much. In this case, you can build the
+builder using either nix or cabal. Directions for both are given below:
 
-If you want to ensure that you are using the correct versions of all of the
-libraries, you can develop inside of a nix shell. To do that, simply type:
+<a id="buildingWithoutNix"></a>
+### Manually Building the Site With Cabal
 
-`nix-shell` from either the project root directory or the `builder` directory.
+If you don't have nix installed, or if you are inside of the project's nix
+shell, you will want to use cabal to compile the builder. To do so, enter the
+`builder` directory and compile the program with:
 
-To build the builder with cabal, go into the `builder` directory and run:
-
-```
+```shell
 cabal v2-build
 ```
 
-### Manually Building the Site with the Builder
+Once compiled, the builder must be run from the project root directory so that
+it can find all of the content. To run the builder, you need to first find the
+name of the executable. From the builder directory, you can find the executable
+path by running:
 
-If you want to manually build the site with the builder, you need to run the
-builder from the project root directory. You can do this by building the site
-with nix:
+```
+find dist-newstyle -name 'haskell-org-site' -type f
+```
+
+Using that path, you can run the builder from the project root directory.
+
+### Manually Building the Site With Nix
+
+If you have nix installed, you can have nix build the builder by running:
 
 ```
 nix-build -A builder
 ```
 
-Then running the builder binary from the `result` directory:
+You may then run the builder binary from the `result` directory:
 
 ```
 ./result/bin/haskell-org-site build
-```
-
-Alternatively you can build with cabal and run the executable directly:
-
-```
-./builder/dist-newstyle/build/x86_64-linux/ghc-8.8.4/haskell-org-0.1.0.0/x/haskell-org-site/build/haskell-org-site/haskell-org-site build
 ```

--- a/buildAndWatch
+++ b/buildAndWatch
@@ -1,17 +1,116 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-if [[ -n "${IN_NIX_SHELL+x}" ]]; then
-    echo "buildAndWatch does not work inside of a nix shell. Please exit the nix-shell and retry."
-    exit 1
-fi
+function buildAndWatchWithNix() {
+    if [[ -n "${IN_NIX_SHELL+x}" ]]; then
+        echo "buildAndWatch does not work inside of a nix shell. Please exit the nix-shell and retry."
+        exit 1
+    fi
 
-if [[ ! -x $(type -P "nix-build") ]]; then
-    echo "nix-build is not available. Please install nix from https://nixos.org/download.html"
-    exit 1
-fi
+    if [[ ! -x $(type -P "nix-build") ]]; then
+        echo "nix-build is not available. Please install nix from https://nixos.org/download.html"
+        exit 1
+    fi
 
-nix-build -A builder && \
-    ./result/bin/haskell-org-site clean && \
-    ./result/bin/haskell-org-site build && \
-    ./result/bin/haskell-org-site watch
+    nix-build -A builder && \
+        ./result/bin/haskell-org-site clean && \
+        ./result/bin/haskell-org-site build && \
+        ./result/bin/haskell-org-site watch
+    exit 0
+}
+
+function buildAndWatchWithoutNix() {
+    if [[ ! -x $(type -P "cabal") ]]; then
+        echo "Please download and install a haskell environment. See: https://www.haskell.org/downloads/"
+        exit 1
+    fi
+
+    pushd builder
+    cabal v2-build
+    builderPath=$(find dist-newstyle -name 'haskell-org-site' -type f)
+    popd
+    builder="./builder/${builderPath}"
+
+    if [[ ! -x "${builder}" ]]; then
+        cat <<EOF
+After building 'haskell-org-site' I was unable to find the path to a
+runnable executable. This may be because of a bug in this script. You
+may want to try to build and run the builder manually, ask for help,
+or submit a bug report.
+EOF
+        exit 1
+    fi
+
+    "${builder}" clean
+    "${builder}" build
+    "${builder}" watch
+    exit 0
+}
+
+function buildAndWatchAuto() {
+    if [[ -x $(type -P "nix-build") ]]; then
+        if [[ -n "${IN_NIX_SHELL+x}" ]]; then
+            cat <<EOF
+I found a 'nix' installation, but we're currently inside of a nix
+shell. I will try to build using cabal. If building with cabal fails,
+you should try to re-run this script when you are not inside of a nix
+shell.
+EOF
+            buildAndWatchWithoutNix
+        else
+            buildAndWatchWithNix
+        fi
+    else
+        buildAndWatchWithoutNix
+    fi
+}
+
+function showHelp() {
+    cat <<EOF
+Usage: buildAndWatch [buildMode]
+
+Build the haskell.org site builder, compile the site, and start a
+local server on port 8000 to preview changes.
+
+buildAndWatch takes a single optional argument, 'buildMode'. If it's
+omitted, buildAndWatch will attempt to select the best method for
+building the site based on your current environment. If you provide an
+argument, it may be one of the following:
+
+  auto (default)      Automatically select between 'nix' or 'cabal' based on the
+                        current environment.
+  nix                 Use nix to build the site
+  cabal               Use cabal to build the site. If you are in a nix shell,
+                        it will use your nix environment. Otherwise, it will use
+                        your system-wide cabal installation.
+  help                Show this help message and exit
+EOF
+}
+
+
+function buildAndWatchWithArgs() {
+    case ${1} in
+        "auto")
+            buildAndWatchAuto
+            ;;
+        "nix")
+            buildAndWatchWithNix
+            ;;
+        "cabal")
+            buildAndWatchWithoutNix
+            ;;
+        "help")
+            showHelp
+            ;;
+        *)
+            echo "Unrecognized or missing arguments"
+            showHelp
+            exit 1
+    esac
+}
+
+if [[ $# -gt 0 ]]; then
+    buildAndWatchWithArgs "${1}"
+else
+    buildAndWatchWithArgs "auto"
+fi

--- a/buildAndWatch
+++ b/buildAndWatch
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+if [[ -n "${IN_NIX_SHELL+x}" ]]; then
+    echo "buildAndWatch does not work inside of a nix shell. Please exit the nix-shell and retry."
+    exit 1
+fi
+
+if [[ ! -x $(type -P "nix-build") ]]; then
+    echo "nix-build is not available. Please install nix from https://nixos.org/download.html"
+    exit 1
+fi
+
+nix-build -A builder && \
+    ./result/bin/haskell-org-site clean && \
+    ./result/bin/haskell-org-site build && \
+    ./result/bin/haskell-org-site watch

--- a/builder/default.nix
+++ b/builder/default.nix
@@ -27,10 +27,8 @@
   LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
   LC_ALL = "C.UTF-8";
   shellHook = ''
-        alias buildAndWatch="cabal configure && cabal build && cabal exec haskell-org-site -- clean && cabal exec haskell-org-site -- watch"
         echo ""
         echo "  Haskell.org Dev Shell"
-        echo "    \`buildAndWatch\` to serve the site, and rebuild when files change."
         echo "    \`linkchecker\`, \`ghcid\` and \`cabal\` are provided in this environment."
         echo ""
       '';


### PR DESCRIPTION
This change is intended to make it a little bit easier for new contributors to get started, and to address an issue with the buildAndWatch shell alias inside of the nix shell.

Change summary:

- Remove the `buildAndWatch` shell alias from the builder's nix-shell, since this didn't seem to work properly
- Add a `buildAndWatch` shell script that provides the same functionality as the shell alias, but runs from outside of a nix shell
- Update the README file to point to the new `buildAndWatch` script, and to try to present an easier to follow workflow for making changes.