### PR TITLE
List subsites

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,6 @@ This is the website for www.haskell.org built as a hakyll static site, which bui
 
 * [The PR policy of this repository](https://github.com/haskell-org/committee/blob/main/proposals/0003-pr-process.md)
 
-### Subsites
-
-Not all subsites of www.haskell.org are built from this repository.
-Some of the others are
-
-* www.haskell.org/cabal (built from [cabal-website](https://github.com/haskell/cabal-website))
-* www.haskell.org/platform (built from [haskell-platform](https://github.com/haskell/haskell-platform/tree/master/website))
-* www.haskell.org/ghcup (build from [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs/-/tree/master/www)
-
 ### Contributing Changes
 
 The easiest way to make changes is to use the `buildAndWatch` script and then
@@ -82,3 +73,101 @@ You may then run the builder binary from the `result` directory:
 ### Deploying
 
 The site will automatically be deployed live to <http://www.haskell.org/> every time a branch is merged to `master`. Alternatively an admin for this GitHub repository can deploy the site by visiting the [Deploy workflow page](https://github.com/haskell-infra/www.haskell.org/actions/workflows/deploy.yml), clicking the "Run workflow" dropdown, choosing the branch to build and deploy, and clicking the "Run workflow" button.
+
+### Subsites
+
+Not all subsites of www.haskell.org are built from this repository.
+Some of the others are
+
+| Subsite | Source | Owner | Details |
+| --------------- | --------------- | --------------- | --------------- |
+| [`cabal/`](https://www.haskell.org/cabal/) | [cabal-website](https://github.com/haskell/cabal-website) | Cabal maintainers | [Details](#details-cabal) |
+| [`ghc/`](https://www.haskell.org/ghc/) | |  | [Details](#details-ghc) |
+| [`ghc-perf/`](https://www.haskell.org/ghc-perf/) | | Joachim Breitner | [Details](#details-ghc-perf) |
+| [`ghcup/`](https://www.haskell.org/ghcup/) | [ghcup-hs](https://gitlab.haskell.org/haskell/ghcup-hs/-/tree/master/www) | Julian Ospald | |
+| [`haddock/`](https://www.haskell.org/haddock/) | Redirect | Haddock maintainers | [Details](#details-haddock) |
+| [`haskell-symposium/`](https://www.haskell.org/haskell-symposium/) | | Haskell Symposium organisers | |
+| [`platform/`](https://www.haskell.org/platform/) | Redirect | | |
+| [`alex/`](https://www.haskell.org/alex/) | | Alex maintainers | [Details](#details-alex) |
+| [`arrows/`](https://www.haskell.org/arrows/) | | Ross Patterson | |
+| [`communities/`](https://www.haskell.org/communities/) | | | [Details](#details-communities) |
+| [`definition/`](https://www.haskell.org/definition/) | | Haskell Prime committee | [Details](#details-definition) |
+| [`happy/`](https://www.haskell.org/happy/) | | Happy maintainers | [Details](#details-happy) |
+| [`haskell-workshop/`](https://www.haskell.org/haskell-workshop/) | | Haskell Symposium organisers | [Details](#details-haskell-workshop) |
+| [`hugs/`](https://www.haskell.org/hugs/) | | | [Details](#details-hugs) |
+| [`nhc98/`](https://www.haskell.org/nhc98/) | | York Functional Programming Group | [Details](#details-nhc98) |
+| [`onlinereport/`](https://www.haskell.org/nhc98/) | | Haskell Prime committee | [Details](#details-onlinereport) |
+| [`tutorial/`](https://www.haskell.org/tutorial/) | | | [Details](#details-tutorial) |
+
+#### Details on subsites
+
+* <a name="details-cabal"></a>
+  `cabal/`
+
+  At least @emilypi has deploy permissions.
+
+* <a name="details-ghc"></a>
+  `ghc/`
+
+  Probably owned by the GHC team.  Most likely @bgamari is the best
+  contact point.
+
+* <a name="details-ghc-perf"></a>
+  `ghc-perf/`
+
+  Same as https://perf.haskell.org
+
+* <a name="details-alex"></a>
+  `alex/`
+
+* <a name="details-communities"></a>
+  `communities/`
+
+  Just contains a link to the HCAR page on this Haskell wiki
+
+* <a name="details-definition"></a>
+  `definition/`
+
+  Last update: 21 June 2005.  [Should be owned
+  by](https://github.com/haskell-infra/www.haskell.org/pull/103#issuecomment-877643716)
+  the same owners as [`onlinereport`](#details-onlinereport).
+
+* <a name="details-haddock"></a>
+  `haddock/`
+
+* <a name="details-happy"></a>
+  `happy/`
+
+* <a name="details-haskell-workshop"></a>
+  `haskell-workshop/`
+
+  Archival page.  Not updated since 2008.  Source is linked as
+  http://abridgegame.org/darcs/ but that link seems long-dead.
+  [Ultimately the responsibility of the Haskell Symposium
+  organisers](https://github.com/haskell-infra/www.haskell.org/pull/103#issuecomment-877643716).
+
+* <a name="details-hugs"></a>
+  `hugs/`
+
+  Archival page.  Not updated since 2003. Report problems to
+  <hugs-bugs@haskell.org>.  Mark Jones and Malcolm Wallace [suggested
+  as](https://github.com/haskell-infra/www.haskell.org/pull/103#issuecomment-877643716)
+  the points of contact.
+
+* <a name="details-nhc98"></a>
+  `nhc98/`
+
+  Archival page.  This page last modified: 9th July 2010.  Not updated
+  since 2010.  Mark Jones and Malcolm Wallace [suggested
+  as](https://github.com/haskell-infra/www.haskell.org/pull/103#issuecomment-877643716)
+  the points of contact.
+
+* <a name="details-onlinereport"></a>
+  `onlinereport/`
+
+* <a name="details-tutorial"></a>
+  `tutorial/`
+
+  Revised June 2000. "This code has been tested with Hugs
+  98". Copyright (C) 1999 Paul Hudak, John Peterson and Joseph Fasel.
+  Perhaps confer with Paul Hudak's former students and collaborators.


### PR DESCRIPTION
It would be very helpful to collect the list of `www.haskell.org` subsites in one place. Eventually I would like to gather more information about their source and owners.

The table is split into two sections: subsites that are reasonably up-to-date and subsites that aren't. Within the sections the subsites appear in alphabetical order..