### PR TITLE
resize testimonials to 300px wide

### DIFF
--- a/js/glider.js
+++ b/js/glider.js
@@ -1,6 +1,0 @@
-window.addEventListener('load', function(){
-    new Glider(document.querySelector('.glider'), {
-      setting: setting-value
-    })
-  })
-  

--- a/js/home.js
+++ b/js/home.js
@@ -8,13 +8,6 @@ $(function(){
   });
 });
 
-window.addEventListener('load', function(){
-  new Glider(document.querySelector('.glider'), {
-    setting: setting-value
-  })
-})
-
-
 // Setup hovering of video thumbnails
 function setupVids(){
   var $community = $('.community');

--- a/templates/testimonials.html
+++ b/templates/testimonials.html
@@ -51,7 +51,7 @@
         // Set to `auto` and provide item width to adjust to viewport
         slidesToShow: 'auto',
         slidesToScroll: 'auto',
-        itemWidth: 150,
+        itemWidth: 300,
         duration: 0.25
       }
     },{
@@ -60,7 +60,7 @@
       settings: {
         slidesToShow: 4,
         slidesToScroll: 1,
-        itemWidth: 150,
+        itemWidth: 300,
         duration: 0.25
       }
     }


### PR DESCRIPTION
Before this change, testimonials would be squeezed uncomfortably tight on narrow viewports. This PR sets the width to 300px unconditionally, and also deletes a couple of confusing static files related to the `glider.js` widget but apparently not used.

After the resize:

<img width="1138" alt="Screen Shot 2021-07-13 at 10 51 04 PM" src="https://user-images.githubusercontent.com/993484/125553292-b8be84da-979d-4634-ac71-338fe04326a3.png">

<img width="792" alt="Screen Shot 2021-07-13 at 10 51 18 PM" src="https://user-images.githubusercontent.com/993484/125553315-dc1d1541-b32b-4bd2-80b3-26c150c6032d.png">

cc @rebeccaskinner 