### PR TITLE
Update Fun. Design and Arch. book link

### DIFF
--- a/documentation.markdown
+++ b/documentation.markdown
@@ -22,7 +22,7 @@ isDocumentation: true
 
 ## Intermediate Haskell Books
 
-*   [Functional Design and Architecture](https://leanpub.com/functional-design-and-architecture)
+*   [Functional Design and Architecture](https://www.manning.com/books/functional-design-and-architecture)
 *   [Haskell in Depth](https://www.manning.com/books/haskell-in-depth)
 *   [Parallel and Concurrent Programming in Haskell](https://simonmar.github.io/pages/pcph.html)
 *   [Practical Haskell](https://www.apress.com/gp/book/9781484244791)


### PR DESCRIPTION
The first edition is no longer being sold, so this new link points to the second edition.