### PR TITLE
Add company backlinks to testimonial logos

### DIFF
--- a/builder/Testimonial.hs
+++ b/builder/Testimonial.hs
@@ -13,6 +13,7 @@ data Testimonial = Testimonial
   { companyName      :: String
   , logoURL          :: String
   , shortTestimonial :: String
+  , companyURL       :: String
   } deriving (Eq, Show, Generic)
 
 instance Binary Testimonial where
@@ -20,8 +21,9 @@ instance Binary Testimonial where
     put companyName
     put logoURL
     put shortTestimonial
+    put companyURL
 
-  get = Testimonial <$> get <*> get <*> get
+  get = Testimonial <$> get <*> get <*> get <*> get
 
 instance Writable Testimonial where
   write path Item{..} =

--- a/builder/site.hs
+++ b/builder/site.hs
@@ -109,4 +109,5 @@ testimonialContext =
   mconcat [ field "companyName" (pure . companyName . itemBody)
           , field "logoURL" (pure . logoURL . itemBody)
           , field "shortTestimonial" (pure . shortTestimonial . itemBody)
+          , field "companyURL" (pure . companyURL . itemBody)
           ]

--- a/templates/testimonials.html
+++ b/templates/testimonials.html
@@ -3,11 +3,13 @@
           $for(testimonials)$
               <div class=" span3 col-xs-6 col-sm-3 testimonial-box" name="testimonial">
                   <div class= "thumbnail">
-                      <a href="$companyURL$" target="_blank">
+                      <a href="$companyURL$">
                           <img width="100px" src="./testimonials/$logoURL$" class="img responsive">
                       </a>
                       <div class="testimonial-caption">
-                          <h4>$companyName$</h4>
+                          <a href="$companyURL$">
+                              <h4>$companyName$</h4>
+                          </a>
                           <h5>$shortTestimonial$</h5>
                       </div>
                       <hr>

--- a/templates/testimonials.html
+++ b/templates/testimonials.html
@@ -3,7 +3,9 @@
           $for(testimonials)$
               <div class=" span3 col-xs-6 col-sm-3 testimonial-box" name="testimonial">
                   <div class= "thumbnail">
-                      <img width="100px" src="./testimonials/$logoURL$" class="img responsive">
+                      <a href="$companyURL$" target="_blank">
+                          <img width="100px" src="./testimonials/$logoURL$" class="img responsive">
+                      </a>
                       <div class="testimonial-caption">
                           <h4>$companyName$</h4>
                           <h5>$shortTestimonial$</h5>

--- a/testimonials/bellroy.yaml
+++ b/testimonials/bellroy.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Bellroy
+companyURL: https://bellroy.com
 logoURL: logos/bellroy.png
 shortTestimonial: |
   We've found the stability, maintainability and performance of

--- a/testimonials/bitnomial.yaml
+++ b/testimonials/bitnomial.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Bitnomial
+companyURL: https://bitnomial.com
 logoURL: logos/bitnomial.png
 shortTestimonial: |
   Haskell gives us huge leverage over our complex business domain

--- a/testimonials/calabrio.yaml
+++ b/testimonials/calabrio.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Calabrio
+companyURL: https://www.calabrio.com/
 logoURL: logos/calabrio.png
 shortTestimonial: |
   At Calabrio we use Haskell to build our Customer Intelligence and

--- a/testimonials/centralapp.yaml
+++ b/testimonials/centralapp.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: CentralApp
+companyURL: https://www.centralapp.com
 logoURL: logos/centralapp.png
 shortTestimonial: |
   We use Haskell... Because solving complex problems well require the

--- a/testimonials/ebot7.yaml
+++ b/testimonials/ebot7.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: E-Bot 7
+companyURL: https://e-bot7.com
 logoURL: logos/ebot7-logo.png
 shortTestimonial: |
   Haskell allows us to create powerful, reliable software with

--- a/testimonials/finn.yaml
+++ b/testimonials/finn.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: finn.no
+companyURL: https://finn.no
 logoURL: logos/finn.png
 shortTestimonial: |
   finn.no is an online classified ad site, and we use Haskell in

--- a/testimonials/foxhoundsystems.yaml
+++ b/testimonials/foxhoundsystems.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Foxhound Systems
+companyURL: https://www.foxhound.systems
 logoURL: logos/foxhoundsystems.png
 shortTestimonial: |
   At Foxhound Systems use Haskell both for client work and our

--- a/testimonials/hasura.yaml
+++ b/testimonials/hasura.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Hasura
+companyURL: https://hasura.io
 logoURL: logos/hasura.png
 shortTestimonial: |
   Haskell is an ideal prototyping tool, when we want to build an MVP

--- a/testimonials/imagineai.yaml
+++ b/testimonials/imagineai.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Imagine AI
+companyURL: https://www.imagine.ai
 logoURL: logos/imagineai.png
 shortTestimonial: |
   ImagineAI is a smart code generator written in Haskell that

--- a/testimonials/iohk.yaml
+++ b/testimonials/iohk.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: IOHK
+companyURL: https://iohk.io
 logoURL: logos/iohk.png
 shortTestimonial: |
   Smart contract systems are largely about programming languages, 

--- a/testimonials/mercury.yaml
+++ b/testimonials/mercury.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Mercury
+companyURL: https://mercury.com
 logoURL: logos/mercury.png
 shortTestimonial: |
   Mercury is a bank for businesses. We use Haskell to meet our

--- a/testimonials/noredink.yaml
+++ b/testimonials/noredink.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: NoRedInk
+companyURL: https://www.noredink.com
 logoURL: logos/noredink.png
 shortTestimonial: |
   The highest-traffic features of noredink.com are now served via

--- a/testimonials/scarf.yaml
+++ b/testimonials/scarf.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Scarf
+companyURL: https://scarf.sh
 logoURL: logos/scarf.png
 shortTestimonial: |
   Haskell powers Scarf's backend, helping us move fast and not break

--- a/testimonials/serokell.yaml
+++ b/testimonials/serokell.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Serokell
+companyURL: https://serokell.io
 logoURL: logos/serokell.png
 shortTestimonial: |
   Haskell enables us to build reliable, performant, and maintainable

--- a/testimonials/stackbuilders.yaml
+++ b/testimonials/stackbuilders.yaml
@@ -1,5 +1,6 @@
 ---
 companyName: Stack Builders
+companyURL: https://www.stackbuilders.com
 logoURL: logos/stackbuilders.png
 shortTestimonial: |
   Haskell makes it possible to maintain an EdTech platform in 23


### PR DESCRIPTION
Closes #118 

This change makes the logos in the testimonial section link back to the companies that gave them. I've added links to all of the companies, so in addition to the merits of the code change, it would be probably be a good idea for someone to double-check I got all of the links correct.