### PR TITLE
Update downloads page

### DIFF
--- a/downloads.markdown
+++ b/downloads.markdown
@@ -16,35 +16,16 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 *   [haskell-language-server](https://github.com/haskell/haskell-language-server) (optional): A language server for developers to integrate with their editor/IDE
 
-Select your platform to get more specific installation instructions:
-
-*   [Linux, OS X and FreeBSD](#linux-mac-freebsd)
-
-*   [Windows](#windows)
-
-Alternative methods to install GHC are listed [here](#ghc-install-manual).
-
-* * *
-
-## Platform specific instructions
-
-### Linux, OS X and FreeBSD { #linux-mac-freebsd }
+## Installation instructions
 
 1. Install GHC, cabal-install and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
 2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
-
-### Windows { #windows }
-
-1. Install GHC and cabal-install via Chocolatey
-	- [Configure Chocolatey](https://chocolatey.org/install) on your machine
-	- At an elevated command prompt, run `choco install haskell-dev`, followed by `refreshenv`.
-2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/#windows)
 
 * * *
 
 ## Alternative installation options { #ghc-install-manual }
 
-*   [Using a package manager on linux](#package-manager)
+*   [Using a package manager](#package-manager)
 
 *   [Official bindists](#bindists)
 
@@ -52,7 +33,9 @@ Alternative methods to install GHC are listed [here](#ghc-install-manual).
 
 *   [Other options](#other-options)
 
-### Using a package manager on Linux { #package-manager }
+### Using a package manager { #package-manager }
+
+#### Linux
 
 Refer to your distribution package manager documentation. For convenience, below are a few distribution specific instructions, outlining 3rd party repository use as well.
 
@@ -162,6 +145,11 @@ sudo emerge --ask dev-lang/ghc dev-haskell/cabal-install
 ```
 
 </div>
+
+#### Windows
+
+1. [Configure Chocolatey](https://chocolatey.org/install) on your machine
+2. At an elevated command prompt, run `choco install haskell-dev haskell-stack`, followed by `refreshenv`.
 
 ### Official bindists { #bindists }
 


### PR DESCRIPTION
Message after @tomjaguarpaw's changes

The specifics of this change are to replace Chocolatey with ghcup as the preferred installation method of GHC, cabal-install and haskell-language-server on Windows. The overall effect is that the install instructions become common over Windows, Linux and MacOS.

In my view this makes something better without making anything worse.  However, the Haskell.org committee can't proceed to merge this without broad community input.

Counterpoints:

* @parsonsmatt suggests that ghcup on Windows is not sufficiently well-tested.

----

@bodigrim's original message

Since #93 has descended into chaos, I’ll take a risk to suggest an alternative, more conservative approach, which merely mentions that ghcup supports Windows and can install Stack, but does not go any further. I hope it could be more palatable, but if I’m wrong feel free to close, no hard feelings on my part.

This PR still offers a considerable simplification and unification, because installation instructions for all major platforms are now uniform.