### PR TITLE
Update downloads page

### DIFF
--- a/downloads.markdown
+++ b/downloads.markdown
@@ -6,7 +6,7 @@ isDownloads: true
 
 # Downloads
 
-This page describes the installation of the Haskell toolchain, which consists of the following tools:
+The Haskell toolchain consists of the following tools:
 
 *   [GHC](https://www.haskell.org/ghc/): the Glasgow Haskell Compiler
 
@@ -16,35 +16,18 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 *   [haskell-language-server](https://github.com/haskell/haskell-language-server) (optional): A language server for developers to integrate with their editor/IDE
 
-Select your platform to get more specific installation instructions:
+To install the Haskell toolchain:
 
-*   [Linux, OS X and FreeBSD](#linux-mac-freebsd)
-
-*   [Windows](#windows)
-
-Alternative methods to install GHC are listed [here](#ghc-install-manual).
-
-* * *
-
-## Platform specific instructions
-
-### Linux, OS X and FreeBSD { #linux-mac-freebsd }
-
-1. Install GHC, cabal-install and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
-2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
-
-### Windows { #windows }
-
-1. Install GHC and cabal-install via Chocolatey
-	- [Configure Chocolatey](https://chocolatey.org/install) on your machine
-	- At an elevated command prompt, run `choco install haskell-dev`, followed by `refreshenv`.
-2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/#windows)
+1. Use [GHCup](https://www.haskell.org/ghcup/) to install
+   GHC, cabal-install and haskell-language-server
+2. Stack can be installed as described on
+   [its install page](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
 * * *
 
 ## Alternative installation options { #ghc-install-manual }
 
-*   [Using a package manager on linux](#package-manager)
+*   [Using a package manager](#package-manager)
 
 *   [Official bindists](#bindists)
 
@@ -52,7 +35,9 @@ Alternative methods to install GHC are listed [here](#ghc-install-manual).
 
 *   [Other options](#other-options)
 
-### Using a package manager on Linux { #package-manager }
+### Using a package manager { #package-manager }
+
+#### Linux
 
 Refer to your distribution package manager documentation. For convenience, below are a few distribution specific instructions, outlining 3rd party repository use as well.
 
@@ -163,11 +148,16 @@ sudo emerge --ask dev-lang/ghc dev-haskell/cabal-install
 
 </div>
 
+#### Windows
+
+1. [Configure Chocolatey](https://chocolatey.org/install) on your machine
+2. At an elevated command prompt, run `choco install haskell-dev haskell-stack`, followed by `refreshenv`.
+
 ### Official bindists { #bindists }
 
 GHC bindists are binary packages built as part of the GHC release process and are guaranteed to have passed the test suite. The installation process is a bit manual, so this is meant for power users.
 
-The [GHC download page](https://www.haskell.org/ghc/download.html) gives an extensive overview of available options. Navigate to the version you seek and click on **Binary packages**. You may also visit [downloads.haskell.org/~ghc](https://downloads.haskell.org/~ghc/) for the complete list. Likewise, to install cabal-install manually visit [downloads.haskell.org/~cabal](https://downloads.haskell.org/~cabal/cabal-install-latest/).
+The [GHC download page](https://www.haskell.org/ghc/download.html) gives an extensive overview of available options. Navigate to the version you seek and click on **Binary packages**. You may also visit [downloads.haskell.org/~ghc](https://downloads.haskell.org/~ghc/) for the complete list. Likewise, to install cabal-install manually visit [downloads.haskell.org/~cabal](https://downloads.haskell.org/~cabal/cabal-install-latest/). Stack binaries can be found on [github.com/commercialhaskell/stack](https://github.com/commercialhaskell/stack/releases).
 
 Haskell-language-server binaries can be found [here](https://github.com/haskell/haskell-language-server/releases/).
 


### PR DESCRIPTION
Minor edits to https://github.com/haskell-infra/www.haskell.org/pull/125 of two types:

* Fix minor typos
* Replace "here" as link text with text describing the link target

I suggest that #125 be replaced with this.