### PR TITLE
Add lhbg to list of introductory books

### DIFF
--- a/site/documentation.markdown
+++ b/site/documentation.markdown
@@ -22,6 +22,7 @@ If you are new to Haskell and are not sure where to start from, we recommend [CI
 *   \[$$\] [Haskell: The Craft of Functional Programming](http://www.haskellcraft.com/craft3e/Home.html)
 *   \[$$\] [The Haskell School of Music](http://euterpea.com/haskell-school-of-music/)
 *   \[$$\] [Get Programming with Haskell](https://www.manning.com/books/get-programming-with-haskell)
+*   [Learn Haskell by building a blog generator](https://lhbg-book.link)
 
 ## Intermediate Haskell Books
 


### PR DESCRIPTION
Can I add [lhbg](https://lhbg-book.link) to the list of intro books under the documentation page?