### PR TITLE
Specify which systems the installation instructions support

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -18,6 +18,8 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 ## Installation instructions
 
+*for Linux, macOS, FreeBSD, Windows or WSL2*
+
 1. Install GHC, cabal-install and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
 2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
 


### PR DESCRIPTION
I'm not 100% sure Stack supports FreeBSD so I asked them: https://github.com/commercialhaskell/stack/issues/5674. Even if it doesn't I think it's better to merge this and adjust the Stack info later.