### PR TITLE
Add platform/ page describing that the Haskell Platform is deprecated

### DIFF
--- a/site/platform.markdown
+++ b/site/platform.markdown
@@ -1,0 +1,13 @@
+---
+title: Haskell Platform
+page: platform
+isDownloads: true
+---
+
+# Haskell Platform
+
+## The Haskell Platform is deprecated
+
+The Haskell Platform is deprecated since 2022 and is no longer the
+recommended way of installing Haskell.  For the latest recommended way
+to install Haskell please see the [Downloads](/downloads/) page.


### PR DESCRIPTION
and link to the Downloads page instead

Part of:

* https://github.com/haskell-infra/www.haskell.org/issues/164
* https://github.com/haskell-infra/www.haskell.org/issues/165