### PR TITLE
Note that Stack does not support FreeBSD

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -21,7 +21,7 @@ This page describes the installation of the Haskell toolchain, which consists of
 *for Linux, macOS, FreeBSD, Windows or WSL2*
 
 1. Install GHC, cabal-install and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
-2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
+2. To install stack, follow the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/) *(N.B. stack does not support FreeBSD)*
 
 * * *
 


### PR DESCRIPTION
It seems that [Stack doesn't support FreeBSD](https://github.com/commercialhaskell/stack/issues/5674) so we should probably note that fact.

### What it looks like now

![screenshot](https://user-images.githubusercontent.com/1951567/152951535-2d3d4d46-9a83-43f1-83b1-a02f68cc414b.png)
