### PR TITLE
bump hakyll upper bound to <4.16

### DIFF
--- a/builder/haskell-org.cabal
+++ b/builder/haskell-org.cabal
@@ -9,7 +9,7 @@ executable haskell-org-site
   main-is:          site.hs
   other-modules:    Testimonial
   build-depends:    base == 4.*
-                  , hakyll >=4.12 && <4.14
+                  , hakyll >=4.12 && <4.16
                   , aeson
                   , binary
                   , bytestring


### PR DESCRIPTION
When trying to build/run the site locally with GHC 9.2.2 I needed to change the hakyll upper bound. I could have gone incrementally to 4.15.x to find a version that could still build, but found it easier to bump it all the way to 4.16. Haven't seen any breaking changes in the hakyll changelog in the 4.14 -> 4.15.latest changelist.