### PR TITLE
downloads: make it clear that "recommended ways" are alternatives

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -17,8 +17,10 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 *for Linux, macOS, FreeBSD, Windows or WSL2*
 
-1. Install GHC, cabal-install and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
-2. To install Stack, follow the [Stack installation guide](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
+There are two alternatives for obtaining and managing the Haskell toolchain: 
+
+* using [GHCup](https://www.haskell.org/ghcup/),
+* using [Stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
 * * *
 


### PR DESCRIPTION
The current wording ("## Recommended installation instructions ... 1... 2...") makes me think that I should perform both steps (1 and 2), while in fact they are alternatives.

I remember someone brought up this concern before, during one of the later restructurings of Downloads, but I can't remember who and where. So, there are at least two of us who are confused by the current version.