### PR TITLE
Simplify Language Report section of Documentation

### DIFF
--- a/site/documentation.markdown
+++ b/site/documentation.markdown
@@ -101,12 +101,4 @@ Documentation for Haskell libraries is typically available on Hackage. We also h
 
 ## Language Report
 
-The Haskell 2010 language report is available online as [HTML](https://haskell.org/onlinereport/haskell2010/) and as [PDF](https://haskell.org/definition/haskell2010.pdf).
-
-It can also be downloaded as a git repository:
-
-```
-$$ git clone -b h2010 https://github.com/haskell/haskell-report
-```
-
-The differences between GHC and the report can be found [in the GHC User's Guide](http://www.haskell.org/ghc/docs/latest/html/users_guide/bugs.html#haskell-standards-vs-glasgow-haskell-language-non-compliance).
+The Haskell 2010 language report is available online as [HTML](https://haskell.org/onlinereport/haskell2010/) and as [PDF](https://haskell.org/definition/haskell2010.pdf). The [source is available on GitHub](https://github.com/haskell/haskell-report). The differences between GHC and the report can be found [in the GHC User's Guide](http://www.haskell.org/ghc/docs/latest/html/users_guide/bugs.html#haskell-standards-vs-glasgow-haskell-language-non-compliance).


### PR DESCRIPTION
The source repo is not particularly useful.  Let's not remove it for
now, but giving the `git clone` command seems overly specific.  People
that need to clone the repo typically already know how to do it.

Also merge the paragraphs to make this one short paragraph, otherwise
we're making this marginal interest look more useful than it is.