### PR TITLE
Add haskell.mooc.fi

### DIFF
--- a/site/documentation.markdown
+++ b/site/documentation.markdown
@@ -44,6 +44,7 @@ Course material created by instructors
 *   [University of Virginia's CS 1501](http://shuklan.com/haskell/)
 *   [Stanford's cs240h](http://www.scs.stanford.edu/14sp-cs240h/)
 *   [Hendrix's CSCI 360](http://ozark.hendrix.edu/~yorgey/360/f16/)
+*   [University of Helsinki's Haskell MOOC](https://haskell.mooc.fi/)
 
 ## Tutorials
 


### PR DESCRIPTION
I wasn't able to test this locally, buildAndWatch ended with an error `[ERROR] _cache/a98f5fd1dec8ada591e76ae4112817f9 for Hakyll.Core.Resource.Provider.MetadataCache/community.markdown/body: Store.set: invalid argument (invalid byte sequence)`, but I'm fairly sure it is correct, and this resource has been mentioned several times in the subreddit.