### PR TITLE
nit: punctuation

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -77,7 +77,9 @@ Alternatively, many operating systems provide GHC, cabal and Stack through their
 <div id="collapse-nixos" class="collapse">
 <!-- This installation method is owned by @maralorn -->
 
-*For Nix the package manager on the distribution NixOS and other OS:*
+*[Nix] is the package manager for NixOS and can also be used on other Linux distros and macOS.*
+
+[Nix]: https://nixos.org
 
 * **Using ghcup on NixOS does not work.** Use the official packages instead.
 * You can get started by installing

--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -77,7 +77,7 @@ Alternatively, many operating systems provide GHC, cabal and Stack through their
 <div id="collapse-nixos" class="collapse">
 <!-- This installation method is owned by @maralorn -->
 
-*for Nix the package manager on the distribution NixOS and other OS*
+*For Nix the package manager on the distribution NixOS and other OS:*
 
 * **Using ghcup on NixOS does not work.** Use the official packages instead.
 * You can get started by installing


### PR DESCRIPTION
Tiny PR.

To be honest, I do not understand the sentence (quote):
```
For Nix the package manager on the distribution NixOS and other OS:
```

Does this mean that this advice is applicable to the Nix package manager on all operating systems? If so, I suggest using:
```
For the Nix package manager:
```
or probably better
```
When using the Nix package manager please note:
```

(But then, only NixOS is referenced in the first point).

So maybe we want to fix that right away?