### PR TITLE
Recommend installing Stack via GHCup

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -17,8 +17,7 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 *for Linux, macOS, FreeBSD, Windows or WSL2*
 
-1. Install GHC, cabal-install and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
-2. To install Stack, follow the [Stack installation guide](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
+* Install GHC, cabal-install, Stack and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
 
 * * *
 


### PR DESCRIPTION
In my opinion, the time is right for www.haskell.org to recommend GHCup as the single install tool, for the following reasons:

* It is desirable for users to have a single way to install all of the Haskell toolchain. It is confusing to recommend they use two different installers.
* GHCup has proven to be a reliable installation tool for the Haskell toolchain.
* GHCup has been able to install Stack for the last 15 months
* GHCup [can now manage GHC versions for Stack](https://gitlab.haskell.org/haskell/ghcup-hs/-/merge_requests/285)
* GHCup installs both cabal-install and Stack by default, so it is not "biased" towards one or the other
* The current GHCup and Stack [have been collaborating](https://github.com/haskell-infra/www.haskell.org/issues/212#issuecomment-1272561149) to make sure the two tools play well together

----

This unlocks many follow ups, such as adding simple "getting started" or "start coding" sections, for example:

* https://github.com/haskell-infra/www.haskell.org/pull/214
* https://github.com/haskell-infra/www.haskell.org/pull/208
