### PR TITLE
Emphasise ghcup, demphasise "toolchain"

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -17,7 +17,7 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 *for Linux, macOS, FreeBSD, Windows or WSL2*
 
-* Install GHC, cabal-install, Stack and haskell-language-server via [GHCup](https://www.haskell.org/ghcup/)
+* Use [GHCup](https://www.haskell.org/ghcup/) to install GHC, cabal-install, Stack and haskell-language-server
 
 * * *
 

--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -6,13 +6,6 @@ isDownloads: true
 
 # Downloads
 
-This page describes the installation of the Haskell toolchain, which consists of the following tools:
-
-*   [GHC](https://www.haskell.org/ghc/): the Glasgow Haskell Compiler
-*   [cabal-install](https://cabal.readthedocs.io): the Cabal installation tool for managing Haskell software
-*   [Stack](https://docs.haskellstack.org): a cross-platform program for developing Haskell projects
-*   [haskell-language-server](https://github.com/haskell/haskell-language-server) (optional): A language server for developers to integrate with their editor/IDE
-
 ## Recommended installation instructions
 
 *for Linux, macOS, FreeBSD, Windows or WSL2*
@@ -21,7 +14,16 @@ This page describes the installation of the Haskell toolchain, which consists of
 
 * * *
 
-### Via native OS package manager
+### Find out more about the Haskell toolchain
+
+The Haskell toolchain consists of the following tools:
+
+*   [GHC](https://www.haskell.org/ghc/): the Glasgow Haskell Compiler
+*   [cabal-install](https://cabal.readthedocs.io): the Cabal installation tool for managing Haskell software
+*   [Stack](https://docs.haskellstack.org): a cross-platform program for developing Haskell projects
+*   [haskell-language-server](https://github.com/haskell/haskell-language-server) (optional): A language server for developers to integrate with their editor/IDE
+
+### Installation via native OS package manager
 
 Alternatively, many operating systems provide GHC, cabal and Stack through their native package manager.  The packages are often out-of-date but if you prefer to use this method of installation then you will find useful links below.
 


### PR DESCRIPTION
On this page we want it to be as easy as possible for people to see how to install Haskell. This PR switches to a single "call to action": Use GHCup.

It deemphasises the "Haskell toolchain", which is all very interesting, but shouldn't be the most prominent thing.

(There are lots of other, bigger, improvements we can make, of course, but there's so much low-hanging fruit now that I think we should just make a bunch of incremental improvements and we'll get to a good place.)

![screenshot0](https://user-images.githubusercontent.com/1951567/196669609-032d3d17-c1b2-411b-b580-fded876914f2.png)
