### PR TITLE
Changed unnecesary page route when typing 'help' on interactive shell…

### DIFF
--- a/site/js/tryhaskell.js
+++ b/site/js/tryhaskell.js
@@ -177,8 +177,6 @@ tryhaskell.setPage = function(n,result){
         guide.html(typeof page.guide == 'string'? page.guide : page.guide(result));
         tryhaskell.makeGuidSamplesClickable();
         // Update the location anchor
-        if (tryhaskell.currentPage != null)
-            window.location = '/#step' + n;
         tryhaskell.currentPage = n;
         // Setup a hook for the next page
         var nextPage = tryhaskell.pages.list[n];


### PR DESCRIPTION
…. It causes unexpected behaviour when page is saved locally.

When typing "help" on interactive haskell shell, it tries to change it's route to a section on the page. Which is unecessary. And it also causes unexpected behaviour when the page is saved locally.

It also push many directions on stack while doing the tutorial, and doesn't contribute, because when the page is reloaded, it shows again the first step of the tutorial.