### PR TITLE
Add a big friendly button: "Get Haskell"

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -23,6 +23,14 @@ isHome: true
           <span class='hs-varid'>p</span> <span class='hs-conop'>:</span> <span class='hs-varid'>filterPrime</span> <span class='hs-keyglyph'>[</span><span class='hs-varid'>x</span> <span class='hs-keyglyph'>|</span> <span class='hs-varid'>x</span> <span class='hs-keyglyph'>&lt;-</span> <span class='hs-varid'>xs</span><span class='hs-layout'>,</span> <span class='hs-varid'>x</span> <span class='hs-varop'>`mod`</span> <span class='hs-varid'>p</span> <span class='hs-varop'>/=</span> <span class='hs-num'>0</span><span class='hs-keyglyph'>]</span></pre>
                </div>
             </div>
+            <div class="row" id="get-started-button">
+               <div class="span12 col-sm-12" style="padding-top: 10px;">
+                  <br/>
+                  <p class="text-center">
+                     <a href="/downloads/" class="btn btn-lg btn-primary" style="font-size: 1.5em">Get Haskell</a>
+                  </p>
+               </div>
+            </div>
          </div>
       </div>
    </div>


### PR DESCRIPTION
The button redirects to the downloads page for now, but we can update that if we add a getting started page and think that that's a better link target.

## Before

![screenshot0](https://user-images.githubusercontent.com/1951567/200114730-976d88f5-401a-497a-8ea5-442e31214222.png)

## After

![screenshot1](https://user-images.githubusercontent.com/1951567/200114709-077463a0-3b75-4b80-a698-5c348e5f403c.png)

Credit to @Martinsos

