### PR TITLE
Explicitly set locale to C.UTF-8 inside buildAndWatch script

### DIFF
--- a/buildAndWatch
+++ b/buildAndWatch
@@ -12,6 +12,7 @@ function buildAndWatchWithNix() {
         exit 1
     fi
 
+    export LC_ALL=C.UTF-8       # fix locale error with Hakyll (see #29)
     nix-build -A builder && \
         ./result/bin/haskell-org-site clean && \
         ./result/bin/haskell-org-site build && \


### PR DESCRIPTION
This should fix the problem reported in #29