### PR TITLE
Update committee positions

### DIFF
--- a/site/haskell-org-committee.markdown
+++ b/site/haskell-org-committee.markdown
@@ -44,10 +44,10 @@ The committee consists of 7 members serving 3-year terms. The current members ar
   * Rebecca Skinner (term ends 2025)
   * Théophile "Hécate" Choutri (term ends 2025)
   * Aaron Allen (term ends 2025)
-  * Tom Ellis (term ends 2024)
+  * Tom Ellis (vice chair, vice treasurer) (term ends 2024)
   * Ida Bzowska (term ends 2023)
-  * Ryan Trinkle (term ends 2023)
-  * Tikhon Jelvis (term ends 2023)
+  * Ryan Trinkle (treasurer) (term ends 2023)
+  * Tikhon Jelvis (chair) (term ends 2023)
 
 Committee members do not need to be deep technical Haskell experts.  Instead we look for enthusiasm towards improving the Haskell community.  We aim to represent the different facets of the community.  We aim to be diverse in terms of industry or research, and in terms of gender, race and location.
 


### PR DESCRIPTION
All decided by unanimous vote, 25th January 2023, except Ryan Trinkle treasurer, a position he has held for several years already.