### PR TITLE
Fix link emphasis on Downloads page

### DIFF
--- a/site/downloads.markdown
+++ b/site/downloads.markdown
@@ -10,7 +10,10 @@ isDownloads: true
 
 *for Linux, macOS, FreeBSD, Windows or WSL2*
 
-* Use [GHCup](https://www.haskell.org/ghcup/) to install GHC, cabal-install, Stack and haskell-language-server
+
+* Use <a href="https://www.haskell.org/ghcup/" class="btn btn-xs btn-primary">GHCup</a> to install GHC, cabal-install, Stack and haskell-language-server
+
+<br>
 
 * * *
 
@@ -27,7 +30,7 @@ The Haskell toolchain consists of the following tools:
 
 Alternatively, many operating systems provide GHC, cabal and Stack through their native package manager.  The packages are often out-of-date but if you prefer to use this method of installation then you will find useful links below.
 
-<p><a data-toggle="collapse" href="#collapse-linux" class="btn btn-xs btn-primary">Show Linux distros</a></p>
+<p><a data-toggle="collapse" href="#collapse-linux" class="btn btn-xs">Show Linux distros</a></p>
 
 <div id="collapse-linux" class="collapse">
 
@@ -73,7 +76,7 @@ Alternatively, many operating systems provide GHC, cabal and Stack through their
 **Do not use the Haskell development tools provided by Arch, they are broken.** For more information see [[1]](https://dixonary.co.uk/blog/haskell/cabal-2020) [[2]](https://stackoverflow.com/questions/65643699/what-is-the-suggested-way-of-setting-up-haskell-on-archlinux/65644318#65644318).
 </div>
 
-<p><a data-toggle="collapse" href="#collapse-nixos" class="btn btn-xs btn-primary">Show Nix/NixOS instructions</a></p>
+<p><a data-toggle="collapse" href="#collapse-nixos" class="btn btn-xs">Show Nix/NixOS instructions</a></p>
 
 <div id="collapse-nixos" class="collapse">
 <!-- This installation method is owned by @maralorn -->
@@ -92,7 +95,7 @@ Alternatively, many operating systems provide GHC, cabal and Stack through their
 
 </div>
 
-<p><a data-toggle="collapse" href="#collapse-freebsd" class="btn btn-xs btn-primary">Show FreeBSD packages</a></p>
+<p><a data-toggle="collapse" href="#collapse-freebsd" class="btn btn-xs">Show FreeBSD packages</a></p>
 
 <div id="collapse-freebsd" class="collapse">
 
@@ -102,7 +105,7 @@ Alternatively, many operating systems provide GHC, cabal and Stack through their
   [Stack](https://www.freshports.org/devel/stack/)
 </div>
 
-<p><a data-toggle="collapse" href="#collapse-windows" class="btn btn-xs btn-primary">Show Windows packages</a></p>
+<p><a data-toggle="collapse" href="#collapse-windows" class="btn btn-xs">Show Windows packages</a></p>
 
 <div id="collapse-windows" class="collapse">
 


### PR DESCRIPTION
What happened here is that I removed "btn-primary" class from the 4 buttons at the bottom of the Downloads page, where each of these buttons on click expands into detailed instructions for installation of Haskell toolchain via native OS package manager for specific distribution.

Instead, I put it on GHCup, which is the recommended installation method.

This is what it looked like before:

![image](https://user-images.githubusercontent.com/1536647/215327336-835e4c36-ac56-453e-acc8-8c81999a7572.png)

This is what it looks like now:

![image](https://user-images.githubusercontent.com/1536647/215327619-f89e144c-649e-44b1-adfa-c3a131d5e5f4.png)

I removed it because I felt confident that it was a mistake in the earlier design. The main thing we want visitors to focus on this page is GHCup, then explanation of the toolchain, and only then potentially the installations via native OS package manager. So it is the part of the page that we want to attract the least of the attention, we even have text that says this method of installation is not recommended and should ideally not be used, but then it uses the btn-primary class, which is to be used for the buttons that should be most emphasized, usually used for the CTA (Call To Action) button -> which in this case is GHCup.

I also added one `<br>` before the horizontal line, to make it clearer that recommended installation instructions stop here.