### PR TITLE
State that GHCup does not require root access

### DIFF
--- a/site/get-started.markdown
+++ b/site/get-started.markdown
@@ -26,7 +26,7 @@ A complete Haskell development environment consists of the Haskell toolchain (co
 
 ### GHCup: universal installer
 
-[GHCup](https://www.haskell.org/ghcup/#) is a universal installer for Haskell that will install everything you need to program in Haskell, and will help you manage those installations (update, switch versions, ...). Follow the instructions on the [GHCup webpage](https://www.haskell.org/ghcup/#) to install GHCup. Then use it to install the Haskell toolchain, which consists of:
+[GHCup](https://www.haskell.org/ghcup/#) is a universal installer for Haskell that will install everything you need to program in Haskell, and will help you manage those installations (update, switch versions, ...). GHCup does not require root/admin access. Follow the instructions on the [GHCup webpage](https://www.haskell.org/ghcup/#) to install GHCup. Then use it to install the Haskell toolchain, which consists of:
 
 1. **GHC** (The Haskell compiler) We will use GHC below to run our examples, but in practice you will mostly use a tool like Cabal or Stack to build your code, instead of GHC directly.
 2. **HLS** (The Haskell Language Server) You won't use HLS directly, instead your code editor will use it in the background to provide you with a great experience while editing Haskell code.


### PR DESCRIPTION
When I try new software, I am always wary of installers requiring root access, as I don't want to turn my system into a [FrankenDebian](https://wiki.debian.org/DontBreakDebian). Specifying that GHCup is well behaved in this regard might be of importantce to a sizeable portion of users.

I would like this information to be present, but also to be as unobtrusive as possible (it is a "Get Started!" page, saddling it with too many things is counterproductive), so I welcome suggestions on where to put this.