### PR TITLE
Explicitly set local encoding to UTF-8 in site.hs

### DIFF
--- a/buildAndWatch
+++ b/buildAndWatch
@@ -12,7 +12,6 @@ function buildAndWatchWithNix() {
         exit 1
     fi
 
-    export LC_ALL=C.UTF-8       # fix locale error with Hakyll (see #29)
     nix-build -A builder && \
         ./result/bin/haskell-org-site clean && \
         ./result/bin/haskell-org-site build && \

--- a/default.nix
+++ b/default.nix
@@ -18,9 +18,6 @@ let
       ] ./.;
     buildInputs = [ builder pkgs.linkchecker ];
 
-    LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
-    LC_ALL = "C.UTF-8";
-
     buildPhase = ''
       ${builder}/bin/haskell-org-site build
     '';


### PR DESCRIPTION
This change makes sure that the site executable *always* expects UTF-8, regardless of any locale environment variables. This should avoid problems like #29 and #249 in a more robust way than trying to set the right environment variables in `buildAndWatch` or `shell.nix`.

The diff ended up a bit noisy because of indentation changes; the key change was adding `Encoding.setLocaleEncoding Encoding.utf8` to the beginning of `main`.

I tested this by reproducing the Unicode error (using `nix-shell --pure`) and checking that the Haskell code change fixes the problem.