### PR TITLE
Add Haskell Beginners Course 2022 to Documentation

### DIFF
--- a/site/documentation.markdown
+++ b/site/documentation.markdown
@@ -58,6 +58,7 @@ Short, dense, classic ways to hit the ground running
 *   [Write Yourself a Scheme in 48 Hours](http://en.wikibooks.org/wiki/Write_Yourself_a_Scheme_in_48_Hours)
 *   [Write Yourself a Scheme 2.0](https://wespiser.com/writings/wyas/home.html)
 *   [Learning Haskell](http://learn.hfm.io)
+*   [Haskell Beginners Course 2022](https://github.com/haskell-beginners-2022/course-plan)
 
 ## Online Resources
 


### PR DESCRIPTION
Hey everyone 👋🏻 

I would like to propose the addition of my Haskell Beginners Course 2022 to the `Tutorials` section of the `Documentation` page at Haskell.org:

* https://github.com/haskell-beginners-2022/course-plan

My course has the following features:

* 🆓 It's free
* 💎 I keep it updated
* 📜 The course provides a certificate upon completion
* 📽️ It's rather popular (~20K views on YouTube and ~600 stars on GitHub)
* 🧑‍🏫 I still review solutions weekly
* 👪 Hundreds of people applied and dozens finished successfully

So I believe it could be a good addition to the website documentation page 😌 