### PR TITLE
Add redirects for old urls

### DIFF
--- a/builder/site.hs
+++ b/builder/site.hs
@@ -56,6 +56,12 @@ main = do
                      ctx
         defCompiler indexCtx
 
+    let redirects = [ ("humor/index.html", "https://wiki.haskell.org/Humor")
+                    , ("hat/index.html", "https://wiki.haskell.org/Hat")
+                    , ("development/views.html", "http://web.archive.org/web/20040107202217/http://haskell.org/development/views.html")
+                    ]
+    version "redirects" $ createRedirects redirects
+
     match ("**/*.markdown" .||. "*.markdown") $ do
       route cleanRoute
       compile $ mdCompiler ctx


### PR DESCRIPTION
These redirects are for links in the paper "A History Of Haskell: Being Lazy With Class."

The `createRedirects` function produces html with meta tag redirects ([source](https://jaspervdj.be/hakyll/reference/src/Hakyll.Web.Redirect.html)). I think this should properly handle the following URLs:

- https://www.haskell.org/humor -> https://wiki.haskell.org/Humor
- https://www.haskell.org/hat -> https://wiki.haskell.org/Hat
- https://www.haskell.org/development/views.html -> http://web.archive.org/web/20040107202217/http://haskell.org/development/views.html

Fixes #261.