### PR TITLE
Update install-nix-action and cachix-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v20
+
+      - name: Cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: haskell-org
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       # The CI Github Action also builds the site and puts it in an
       # artifact.  However, downloading an artifact from a different

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v20
 
       - name: Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: haskell-org
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'


### PR DESCRIPTION
Updating install-nix-action should fix #266 (see [cachix @144][1]). I also noticed that `deploy.yml` was not using cachix-action at all, so I updated that as well.

Since we're updating the workflows anyhow, I figure we can also bump `cachix-action` while we're at it—same change as #265 but applied to both workflow files.