### PR TITLE
Removed Data Dog from sponsorship list

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -481,15 +481,7 @@ isHome: true
       </div>
       <div class=" row ">
          <div class=" span6 col-sm-6">
-            <p><strong><a href="https://www.datadoghq.com">DataDog</a></strong> provides powerful, customizable 24/7 metrics and monitoring integration for all of Haskell.org, and complains loudly for us when things go wrong.</p>
-         </div>
-         <div class=" span6 col-sm-6">
             <p><strong><a href="https://www.fastly.com">Fastly</a></strong>&#39;s Next Generation CDN provides low latency access for all of Haskell.org&#39;s downloads and highest traffic services, including the primary Hackage server, Haskell Platform downloads, and more.</p>
-         </div>
-      </div>
-      <div class=" row ">
-         <div class=" span6 col-sm-6">
-            <p><strong><a href="https://metal.equinix.com/">Equinix Metal</a></strong> provides compute, storage, and networking resources, powering almost all of Haskell.org in several regions around the world.</p>
          </div>
          <div class=" span6 col-sm-6">
             <p><strong><a href="https://www.status.io">Status.io</a></strong> powers <a href="https://status.haskell.org">https://status.haskell.org</a>, and lets us easily tell you when we broke something.</p>
@@ -497,10 +489,15 @@ isHome: true
       </div>
       <div class=" row ">
          <div class=" span6 col-sm-6">
-            <p><strong><a href="http://www.galois.com">Galois</a></strong> provides infrastructure, funds, administrative resources and has historically hosted critical Haskell.org infrastructure, as well as helping the Haskell community at large with their work.</p>
+            <p><strong><a href="https://metal.equinix.com/">Equinix Metal</a></strong> provides compute, storage, and networking resources, powering almost all of Haskell.org in several regions around the world.</p>
          </div>
          <div class=" span6 col-sm-6">
             <p><strong><a href="https://www.dreamhost.com">DreamHost</a></strong> has teamed up to provide Haskell.org with redundant, scalable object-storage through their Dream Objects service.</p>
+         </div>
+      </div>
+      <div class=" row ">
+         <div class=" span6 col-sm-6">
+            <p><strong><a href="http://www.galois.com">Galois</a></strong> provides infrastructure, funds, administrative resources and has historically hosted critical Haskell.org infrastructure, as well as helping the Haskell community at large with their work.</p>
          </div>
       </div>
    </div>


### PR DESCRIPTION
Data Dog used to provide monitoring service for us, but looks like we don't use them any more. (See #269 and https://github.com/haskell/play-haskell/issues/21#issuecomment-1570595269)