### PR TITLE
Fix styling of links

### DIFF
--- a/site/css/hl.css
+++ b/site/css/hl.css
@@ -275,7 +275,7 @@ textarea {
 
 a {
   color: #9E358F;
-  text-decoration: underline dotted; }
+  text-decoration: underline ; }
   a:hover, a:focus {
     color: #65225b;
     text-decoration: underline; }

--- a/site/css/hl.css
+++ b/site/css/hl.css
@@ -2032,6 +2032,9 @@ select[multiple].input-lg,
     -webkit-box-shadow: none;
     box-shadow: none; }
 
+a.btn {
+  /* No text-decoration for <a> tags in buttons */
+  text-decoration: none; }
 a.btn.disabled,
 fieldset[disabled] a.btn {
   pointer-events: none; }
@@ -2762,6 +2765,7 @@ tbody.collapse.in {
     .nav > li > a {
       position: relative;
       display: block;
+      text-decoration: none; /* No text-decoration for <a> tags in navbars */
       padding: 10px 15px; }
       .nav > li > a:hover, .nav > li > a:focus {
         text-decoration: none;

--- a/site/css/hl.css
+++ b/site/css/hl.css
@@ -3395,6 +3395,9 @@ a.badge:hover, a.badge:focus {
     word-wrap: break-word;
   }
 
+a.thumbnail {
+  /* No text-decoration for <a> tags in thumbnails */
+  text-decoration: none; }
 a.thumbnail:hover,
 a.thumbnail:focus,
 a.thumbnail.active {


### PR DESCRIPTION
In trying to improve the appearence of the Haskell main webpage a little bit, I've
1. Removed the underline of links that appear
    * inside buttons
    * in the navbar
2. Changed the dotted underline to a solid underline

Screenshots:

Old:

<img width="1440" alt="Screenshot 2023-06-27 at 13 59 32" src="https://github.com/haskell-infra/www.haskell.org/assets/21295306/221d2941-a745-4af5-bc5c-39984944a20f">

<img width="1440" alt="Screenshot 2023-06-27 at 13 59 42" src="https://github.com/haskell-infra/www.haskell.org/assets/21295306/14cc27de-7650-4f96-a99a-83969683949e">

<img width="1440" alt="Screenshot 2023-06-27 at 13 59 49" src="https://github.com/haskell-infra/www.haskell.org/assets/21295306/b19c1532-92f7-422d-9fb7-9bb7a343a2a4">

New:

<img width="1438" alt="Screenshot 2023-06-27 at 11 07 50" src="https://github.com/haskell-infra/www.haskell.org/assets/21295306/f6801201-919f-4820-a810-984e1b6b6dbe">

<img width="1437" alt="Screenshot 2023-06-27 at 11 07 40" src="https://github.com/haskell-infra/www.haskell.org/assets/21295306/c960274e-282e-4cbc-aed4-4afaa23e9c15">

<img width="1439" alt="Screenshot 2023-06-27 at 11 07 34" src="https://github.com/haskell-infra/www.haskell.org/assets/21295306/b3ae96eb-7680-412f-bb7d-4ee85b510835">

I suppose the dotted vs solid underline decision is more contentious, so I've added it as a separate commit we can also just drop.

Thanks!