### PR TITLE
Hide tracking pixel

### DIFF
--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -61,6 +61,6 @@
      <script src="/js/jquery.console.js"></script>
      <script src="/js/tryhaskell.js"></script>
      <script src="/js/tryhaskell.pages.js"></script>
-     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7342a8f5-ceb0-403f-9ac8-72a94963320d" />
+     <img style="position: absolute;" class="invisible" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=7342a8f5-ceb0-403f-9ac8-72a94963320d" />
    </body>
 </html>


### PR DESCRIPTION
**Issue**
This recent [PR](https://github.com/haskell-infra/www.haskell.org/pull/274) added a Scarf tracking pixel. While the link is indeed to a 1px by 1px image, it's currently taking a lot of space at the bottom of the page because it's a flex item.

cc: @TikhonJelvis (stakeholder; added the pixel)

**Summary of changes:**
- remove pixel from flow of page with absolute positioning
- use existing `invisible` class to add `visibility:hidden`

**Testing**
- ensured the pixel is still being loaded by looking at Network tab
- clicked around the site to make sure nothing else started looking funky
---
Demos
**CURRENT**
![Screenshot from 2023-07-17 14-06-59](https://github.com/haskell-infra/www.haskell.org/assets/54204155/9982ec56-89ae-4e12-8516-f10cd3fe8d90)

**AFTER**
![Screenshot from 2023-07-17 14-16-51](https://github.com/haskell-infra/www.haskell.org/assets/54204155/be730bf2-f83f-4a41-9c2a-d35fddfe8f42)
