### PR TITLE
Fix keyboard trap

### DIFF
--- a/site/js/jquery.console.js
+++ b/site/js/jquery.console.js
@@ -63,10 +63,8 @@
             36: moveToStart,
             // return
             13: commandTrigger,
-            // tab
+            // alt
             18: doNothing,
-            // tab
-            9: doComplete
         };
         var ctrlCodes = {
             // C-a
@@ -198,7 +196,6 @@
         };
 
         var focusConsole = function() {
-            inner.addClass('jquery-console-focus');
             typer.focus();
         };
 
@@ -283,6 +280,12 @@
             inner.addClass('jquery-console-nofocus');
         });
 
+        // Handle receiving focus, helpful now that we can use keyboard to navigate to element
+        typer.focus(function() {
+            inner.removeClass('jquery-console-nofocus');
+            inner.addClass('jquery-console-focus');
+        })
+
         ////////////////////////////////////////////////////////////////////////
         // Bind to the paste event of the input box so we know when we
         // get pasted data
@@ -320,6 +323,12 @@
                 cancelExecution();
                 return false;
             }
+            // Handle tab key
+            if (keyCode == 9) {
+                typer.blur();
+                return true
+            }
+            
             if (acceptInput) {
                 if (e.shiftKey && keyCode in shiftCodes) {
                     cancelKeyPress = keyCode;


### PR DESCRIPTION
Currently, if you visit [haskell.org](https://www.haskell.org/) and attempt to navigate with the keyboard, you will find that it's impossible to go through the entire page. This is a major a11y concern, as many users rely on keyboard navigation, often with a screen reader, to navigate sites. Closes #10.

**Summary of changes:** This diff handles the pressing of the "tab" key by removing focus from the current element using the [blur](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/blur) (bad name, IMO) method, and removing the current `doComplete` callback on tab. I also made sure the right styling is applied when focusing on the console by tabbing.

**Testing**
- Browsers used: Firefox, Chrome
- I tabbed through the document and made sure we can land on and leave the console. When focused on the console, it should apply the correct styles and allow us to start typing commands. See attached video.
- In Chrome, the "Accessibility Insights for Web" extension helped me visualize what the tab "steps" were.

**Out of scope:** 
- Next to the console there are buttons to quickly insert commands like "help" by clicking on them. These weren't navigable to before, and that's not addressed here.
- I don't have a screen reader currently set up, so I don't know what a user would hear when focusing on the console. Probably something like "text area"

---
N.B. [The code for this feature is ancient](https://github.com/chrisdone/jquery-console), and likely uses deprecated methods/patterns.

[focus-in-away-tab.webm](https://github.com/haskell-infra/www.haskell.org/assets/54204155/601f099d-9b10-4a02-96cf-64de88f4c51c)
