### PR TITLE
Fix small text a11y issues

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <div class="branding">
                <br class="hidden-xs">
-               <img src="/img/haskell-logo.svg" class="img-responsive">
+               <img src="/img/haskell-logo.svg" alt="Haskell" class="img-responsive">
                <h4 class="summary">An advanced, purely functional programming language</h4>
             </div>
          </div>
@@ -87,7 +87,7 @@ isHome: true
                      <div class=" row row-flex">
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=re96UgMk6GQ" title="Escape from the ivory tower: The Haskell journey, by Simon Peyton-Jones" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/re96UgMk6GQ/mqdefault.jpg" class="img-responsive">
+                              <img src="https://i1.ytimg.com/vi/re96UgMk6GQ/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
                                  <h5>Escape from the ivory tower: The Haskell journey, by Simon Peyton-Jones</h5>
                               </div>
@@ -95,7 +95,7 @@ isHome: true
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=lC5UWG5N8oY" title="Haskell taketh away: limiting side effects for parallel programming, by Ryan Newton" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/lC5UWG5N8oY/mqdefault.jpg" class="img-responsive">
+                              <img src="https://i1.ytimg.com/vi/lC5UWG5N8oY/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
                                  <h5>Haskell taketh away: limiting side effects for parallel programming, by Ryan Newton</h5>
                               </div>
@@ -103,7 +103,7 @@ isHome: true
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=AZQLkkDXy68" title="Production Haskell, by Reid Draper" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/AZQLkkDXy68/mqdefault.jpg" class="img-responsive">
+                              <img src="https://i1.ytimg.com/vi/AZQLkkDXy68/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
                                  <h5>Production Haskell, by Reid Draper</h5>
                               </div>
@@ -111,7 +111,7 @@ isHome: true
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=b9FagOVqxmI" title="Haskell Amuse-Bouche, by Mark Lentczner" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/b9FagOVqxmI/mqdefault.jpg" class="img-responsive">
+                              <img src="https://i1.ytimg.com/vi/b9FagOVqxmI/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
                                  <h5>Haskell Amuse-Bouche, by Mark Lentczner</h5>
                               </div>
@@ -119,7 +119,7 @@ isHome: true
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=mlTO510zO78" title="Haskell is Not For Production and Other Tales, by Katie Miller" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/mlTO510zO78/mqdefault.jpg" class="img-responsive">
+                              <img src="https://i1.ytimg.com/vi/mlTO510zO78/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
                                  <h5>Haskell is Not For Production and Other Tales, by Katie Miller</h5>
                               </div>
@@ -127,7 +127,7 @@ isHome: true
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=Orm-jIIgVD0" title="Your First Web Application with Spock, by Oskar Wickström" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/Orm-jIIgVD0/mqdefault.jpg" class="img-responsive">
+                              <img src="https://i1.ytimg.com/vi/Orm-jIIgVD0/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
                                  <h5>Your First Web Application with Spock, by Oskar Wickström</h5>
                               </div>

--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html lang="en">
    <head>
       <title>$title$</title>
       <meta charset="utf-8">

--- a/site/templates/nav.html
+++ b/site/templates/nav.html
@@ -3,7 +3,7 @@
       <div class="navbar-header">
         <button data-toggle="collapse" data-target="#haskell-menu" class="navbar-toggle collapsed"><span class="sr-only"></span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button>
         $if(isHome)$ $else$
-        <a href="/" class="navbar-brand"><span class="logo"><img src="/img/haskell-logo.svg"></span></a>
+        <a href="/" class="navbar-brand"><span class="logo"><img src="/img/haskell-logo.svg" alt="Homepage"></span></a>
         $endif$
       </div>
       <div id="haskell-menu" class="collapse navbar-collapse">

--- a/site/templates/testimonials.html
+++ b/site/templates/testimonials.html
@@ -4,7 +4,7 @@
               <div class=" span3 col-xs-6 col-sm-3 testimonial-box" name="testimonial">
                   <div class= "thumbnail">
                       <a href="$companyURL$">
-                          <img width="100px" src="./testimonials/$logoURL$" class="img responsive">
+                          <img width="100px" src="./testimonials/$logoURL$" alt="$companyName$: Logo" class="img responsive">
                       </a>
                       <div class="testimonial-caption">
                           <a href="$companyURL$">


### PR DESCRIPTION
Mainly, adding the `alt` attribute where needed.
`alt` with no value means the image is for decoration only, like the video thumbnails.