### PR TITLE
"Features" section improvements

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -164,7 +164,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Statically typed</h3>
             <p>Every expression in Haskell has a type which is determined at compile time. All the types composed together by function application have to match up. If they don&#39;t, the program will be rejected by the compiler. Types become not only a form of guarantee, but a language for expressing the construction of programs.</p>
-            <p class="text-center"><a data-toggle="collapse" href="#collapse-statically-typed" class="btn btn-xs btn-primary">Click to expand</a></p>
+            <p class="text-center"><a data-toggle="collapse" href="#collapse-statically-typed" class="btn btn-xs btn-primary">Show more</a></p>
             <div id="collapse-statically-typed" class="collapse">
                <p>All Haskell values have a type:</p>
                <pre><span class='hs-definition'>char</span> <span class='hs-keyglyph'>=</span> <span class='hs-chr'>'a'</span>    <span class='hs-keyglyph'>::</span> <span class='hs-conid'>Char</span>
@@ -190,7 +190,7 @@ isHome: true
 <div class=" span6 col-md-6">
    <h3>Purely functional</h3>
    <p>Every function in Haskell is a function in the mathematical sense (i.e., &quot;pure&quot;). Even side-effecting IO operations are but a description of what to do, produced by pure code. There are no statements or instructions, only expressions which cannot mutate variables (local or global) nor access state like time or random numbers.</p>
-   <p class="text-center"><a data-toggle="collapse" href="#collapse-functional" class="btn btn-xs btn-primary">Click to expand</a></p>
+   <p class="text-center"><a data-toggle="collapse" href="#collapse-functional" class="btn btn-xs btn-primary">Show more</a></p>
    <div id="collapse-functional" class="collapse">
       <p>The following function takes an integer and returns an integer. By the type it cannot do any side-effects whatsoever, it cannot mutate any of its arguments.</p>
       <pre><span class='hs-definition'>square</span> <span class='hs-keyglyph'>::</span> <span class='hs-conid'>Int</span> <span class='hs-keyglyph'>-&gt;</span> <span class='hs-conid'>Int</span>
@@ -210,7 +210,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Type inference</h3>
             <p>You don&#39;t have to explicitly write out every type in a Haskell program. Types will be inferred by unifying every type bidirectionally. However, you can write out types if you choose, or ask the compiler to write them for you for handy documentation.</p>
-            <p class="text-center"><a data-toggle="collapse" href="#collapse-type-inference" class="btn btn-xs btn-primary">Click to expand</a></p>
+            <p class="text-center"><a data-toggle="collapse" href="#collapse-type-inference" class="btn btn-xs btn-primary">Show more</a></p>
             <div id="collapse-type-inference" class="collapse">
                <p>This example has a type signature for every binding:</p>
                <pre><span class='hs-definition'>main</span> <span class='hs-keyglyph'>::</span> <span class='hs-conid'>IO</span> <span class='hs-conid'>()</span>
@@ -243,7 +243,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Concurrent</h3>
             <p>Haskell lends itself well to concurrent programming due to its explicit handling of effects. Its flagship compiler, GHC, comes with a high-performance parallel garbage collector and light-weight concurrency library containing a number of useful concurrency primitives and abstractions.</p>
-            <p class="text-center"><a data-toggle="collapse" href="#collapse-concurrent" class="btn btn-xs btn-primary">Click to expand</a></p>
+            <p class="text-center"><a data-toggle="collapse" href="#collapse-concurrent" class="btn btn-xs btn-primary">Show more</a></p>
             <div id="collapse-concurrent" class="collapse">
                <p>Easily launch threads and communicate with the standard library:</p>
                <pre><span class='hs-definition'>main</span> <span class='hs-keyglyph'>=</span> <span class='hs-keyword'>do</span>
@@ -278,7 +278,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Lazy</h3>
             <p>Functions don&#39;t evaluate their arguments. This means that programs can compose together very well, with the ability to write control constructs (such as if/else) just by writing normal functions. The purity of Haskell code makes it easy to fuse chains of functions together, allowing for performance benefits.</p>
-            <p class="text-center"><a data-toggle="collapse" href="#collapse-lazy" class="btn btn-xs btn-primary">Click to expand</a></p>
+            <p class="text-center"><a data-toggle="collapse" href="#collapse-lazy" class="btn btn-xs btn-primary">Show more</a></p>
             <div id="collapse-lazy" class="collapse">
                <p>Define control structures easily:</p>
                <pre><span class='hs-definition'>when</span> <span class='hs-varid'>p</span> <span class='hs-varid'>m</span> <span class='hs-keyglyph'>=</span> <span class='hs-keyword'>if</span> <span class='hs-varid'>p</span> <span class='hs-keyword'>then</span> <span class='hs-varid'>m</span> <span class='hs-keyword'>else</span> <span class='hs-varid'>return</span> <span class='hs-conid'>()</span>
@@ -299,7 +299,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Packages</h3>
             <p>Open source contribution to Haskell is very active with a wide range of packages available on the public package servers.</p>
-            <p class="text-center"><a data-toggle="collapse" href="#collapse-packages" class="btn btn-xs btn-primary">Click to expand</a></p>
+            <p class="text-center"><a data-toggle="collapse" href="#collapse-packages" class="btn btn-xs btn-primary">Show more</a></p>
             <div id="collapse-packages" class="collapse">
                <p>There are 6,954 packages freely available. Here is a sample of the most common ones:</p>
                <table class="packages">

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -4,7 +4,23 @@ $(function () {
 });
 
 function handleFeaturesCollapse() {
+  // Allows the area/wrapper around feature copy to toggle collapse,
+  // not just the expand link as set in the markup
+  // https://getbootstrap.com/docs/4.0/components/collapse/#via-data-attributes
   $(".features .col-md-6").click(function () {
     $(this).find(".collapse").collapse("toggle");
+  });
+
+  const ELEMENT_SHOWN_EVENT = "shown.bs.collapse";
+  const ELEMENT_HIDDEN_EVENT = "hidden.bs.collapse";
+
+  $(".collapse").on(ELEMENT_HIDDEN_EVENT, function () {
+    const featureSelector = $(this).context.id;
+    $(`.features a[href="#${featureSelector}"]`).text("Show more");
+  });
+
+  $(".collapse").on(ELEMENT_SHOWN_EVENT, function () {
+    const featureSelector = $(this).context.id;
+    $(`.features a[href="#${featureSelector}"]`).text("Show less");
   });
 }

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -1,57 +1,7 @@
 // Main entry point
 $(function(){
-  //setupVids();
-  //setupFeatures();
-
   $('.features .col-md-6').click(function(){
     $(this).find('.collapse').collapse('toggle');
   });
 });
-
-// Setup hovering of video thumbnails
-function setupVids(){
-  var $community = $('.community');
-  var $videos = $('.videos');
-  var $tagline = $('#tagline');
-  var $videoDesc = $('#video-description');
-  var $videoAnchor = $('#video-anchor');
-  var $videoView = $('#video-view');
-  var originalBackground = $community.css('background');
-
-  $videoDesc.hide();
-  // To keep a consistent height between transitions
-  $videoDesc.css('height',$tagline.height());
-
-  $('.vid-thumbnail').each(function(){
-    var $this = $(this);
-    var title = $this.attr('title');
-    var href = $this.attr('href');
-    $this.click(select);
-    function select(){
-      $videos.find('.current').removeClass('current');
-      $this.addClass('current');
-      $videoAnchor.text(title);
-      $videoAnchor.attr('href',href);
-      $videoView.attr('href',href);
-      $tagline.hide();
-      $videoDesc.show();
-      $community.css('background','#111111');
-      return false;
-    }
-  });
-}
-
-// Expandable features
-function setupFeatures(){
-  $('.features .span6').each(function(){
-    var $this = $(this);
-    $this.click(function(){
-      $this.find('.expandable').slideToggle(function(){
-        $this.find('.expand').slideToggle('fast');
-      });
-    });
-    if ($this.find('.expandable').size() == 0)
-      $this.find('.expand').hide();
-  });
-}
 

--- a/site/js/home.js
+++ b/site/js/home.js
@@ -1,7 +1,10 @@
 // Main entry point
-$(function(){
-  $('.features .col-md-6').click(function(){
-    $(this).find('.collapse').collapse('toggle');
-  });
+$(function () {
+  handleFeaturesCollapse();
 });
 
+function handleFeaturesCollapse() {
+  $(".features .col-md-6").click(function () {
+    $(this).find(".collapse").collapse("toggle");
+  });
+}


### PR DESCRIPTION
This PR proposes:
- removing unused code from `home.js`
- changing the copy of the features section's collapse buttons to say “Show more”
- change collapse buttons to have a different copy when toggled (“Show less”)

What do you all think of the copy changes? I think this is a slight improvement from “Click to expand” since the styling of the link already indicates the user can click there. Alternatively, we could have “Click to expand” and “Click to hide”.

An outstanding issue is that each feature should probably indicate that it can be clicked to toggle collapse outside the link button. Once resolved, there might not be a need for a separate button. A designer's opinion would be great :sweat_smile: 

![Screenshot from 2023-09-28 16-28-39](https://github.com/haskell-infra/www.haskell.org/assets/54204155/30889806-f307-4bb0-9fc3-e10fe074cb77)

[Screencast from 2023-09-28 16-28-52.webm](https://github.com/haskell-infra/www.haskell.org/assets/54204155/00ddeb65-4c78-470b-bf79-e87ed981182c)
