### PR TITLE
CIS 194 domain has changed

### DIFF
--- a/site/documentation.markdown
+++ b/site/documentation.markdown
@@ -39,7 +39,7 @@ If you are new to Haskell and are not sure where to start from, we recommend [CI
 
 Course material created by instructors
 
-*   [University of Pennsylvania's CIS 194](https://www.seas.upenn.edu/~cis194/)
+*   [University of Pennsylvania's CIS 194](https://www.seas.upenn.edu/~cis1940/spring13/)
 *   [Data61 Functional Programming Course](https://github.com/data61/fp-course)
 *   [Stanford's cs240h](http://www.scs.stanford.edu/14sp-cs240h/)
 *   [Hendrix's CSCI 360](http://ozark.hendrix.edu/~yorgey/360/f16/)


### PR DESCRIPTION
The website domain has been changed.
Fixed it to point to the right course of 2013, since 2023 course has no materials.