### PR TITLE
add RFP for site redesign

### DIFF
--- a/site/rfp/haskell-org-redesign-rfp.markdown
+++ b/site/rfp/haskell-org-redesign-rfp.markdown
@@ -1,0 +1,114 @@
+---
+title: Haskell.org Redesign RFP
+page: haskell-org-redesign-rfp
+---
+
+# Current Status
+
+This RFP is currently **Open** and we are actively soliciting proposals.
+
+# Introduction
+
+Haskell.org, a 501(c)(3) non-profit organization, operates and maintains the
+website at [http://haskell.org](https://www.haskell.org). Our team, primarily
+composed of committed volunteers, is dedicated to expanding the recognition of
+Haskell and fueling broader interest in the language. We are seeking proposals
+for a website redesign project to update and improve our site's visual design,
+thereby enhancing the user experience for our community.
+
+# Budget and Scope
+
+Haskell.org has allocated up to 2500 USD for this project. The scope
+of work includes a visual overhaul of several key pages on haskell.org,
+specifically the pages titled:
+
+-   Get Started
+-   Downloads
+-   Community
+-   Documentation
+-   Donate
+
+The visual overhaul may include, but is not limited to, changes to the
+layout of the pages, the creation of new graphics and icons, and
+requests to the Haskell.org committee for new text content to be
+included on the pages.
+
+The redesign of these pages should follow a cohesive visual style and
+design language that matches with the design of the haskell.org home
+page. Additionally, while we do not seek a complete visual overhaul to
+the home page of haskell.org, we anticipate that there may be some minor
+changes to this page to conform to changes elsewhere on the site. Please
+note that only pages that are part of the primary [haskell.org
+site](<https://github.com/haskell-infra/www.haskell.org>) are in scope
+for this project.
+
+We are open to proposals covering a reduced scope of work, as long as
+the end result is production-ready. The final deliverables for this
+project should include all necessary code (HTML, CSS, JavaScript,
+template changes, etc.) and assets (images, fonts) required for the
+site's overhaul. While this is a design-centric project, any minimal
+content changes or copywriting adjustments required to accommodate the
+new design should be included.
+
+# Technical Requirements
+
+Specific technical requirements for the work and deliverables will be
+determined in collaboration with the selected party. However, it's
+vital for proposers to understand the unique constraints and context of
+Haskell.org:
+
+-   We are a non-profit organization with a limited budget.
+-   We don't have dedicated full-time staff, so ease of ongoing
+    maintenance is a significant factor in our review of proposals.
+
+Our current website is statically generated using Hakyll, and its
+content is primarily crafted with markdown, CSS, and a sprinkle of
+JavaScript. The committee and our dedicated volunteers are
+well-acquainted with these technologies. Proposals that extend and
+enhance the existing infrastructure, rather than suggesting a full
+replacement, will be particularly appealing to us. We anticipate that
+given the limited scope of this project, most proposers will opt to
+build upon our current foundation.
+
+Other essential technical considerations include:
+
+-   Ensuring site accessibility.
+-   Compliance with GDPR.
+-   Any implications for hosting, maintenance, or licensing in the
+    future.
+
+# Proposal
+
+Proposals should be emailed to the Haskell.org committee at
+committee@haskell.org. Proposals may be submitted at any time, and will
+be reviewed as they are received until an appropriate proposal has been
+selected. Proposals need not be formal but should include at least:
+
+-   A detailed summary of the work to be completed.
+-   An estimate for the total time to deliver the project.
+-   Any additional services provided such as support and maintenance
+    post-implementation.
+-   An overview of your relevant experience and past portfolio, if any.
+-   Any potential challenges you foresee and how you plan to address
+    them.
+
+# Selection and Notification Process
+
+Proposals will be reviewed by the Haskell.org committee. Each proposal
+will be evaluated based on its thoroughness, the feasibility of the
+timeline, the proposer's relevant experience, and alignment with the
+budget. We may reach out to the proposers for further information or
+clarification during the review process.
+
+The selected proposer will be notified by email as soon as the committee has
+reached a decision. Once a proposer is selected, a contract detailing the scope
+of work, payment terms, and other project specifics will be negotiated. Upon
+acceptance of a proposal, other submitters will be notified via email.
+
+# Contact Information
+
+For any questions or clarifications related to this RFP, please contact
+the Haskell.org committee at committee@haskell.org.
+
+Thank you for considering this opportunity. We look forward to your
+creative and innovative proposals.


### PR DESCRIPTION
This change adds the contents of the haskell.org redesign RFP to the site. It's not linked from the main site. We can link to the page directly, giving us an easy way to share the RFP across multiple sites.

Although the technical change here is pretty safe, I'll hold off on merging this until we get a couple of reviews from other people on the committee.