### PR TITLE
update irc page

### DIFF
--- a/site/irc.markdown
+++ b/site/irc.markdown
@@ -6,15 +6,36 @@ isCommunity: true
 
 # IRC Channels
 
-The IRC channel can be an excellent place to learn more about Haskell, and to just keep in the loop on new things in the Haskell world. Many new developments in the Haskell world first appear on the IRC channel. Haskell channels have been moving from freenode and are now mainly established on [libera.chat](https://libera.chat).
+The IRC channel can be an excellent place to learn more about Haskell, and to just keep in the loop on new things in the Haskell world. Many new developments in the Haskell world first appear on the IRC channel. Haskell channels are hosted on [libera.chat](https://libera.chat).
 
 Point your IRC client to `irc.libera.chat:6697 (TLS)` and then join the `#haskell` channel (or [connect via your web browser](https://web.libera.chat/#haskell)). Check the [guides](https://libera.chat/guides) for more connection information.
 
-## Logs
+*Plain text logs for `#haskell` from before the move to libera.chat (2021) are available at [tunes](http://tunes.org/~nef/logs/haskell/).*
 
-Plain text logs for #haskell from before the move to libera.chat (2021) are available at [tunes](http://tunes.org/~nef/logs/haskell/).
+## Haskell development and community
 
-## Related channels
+<div class="table">
+
+| Channel | Purpose |
+|----|--------------|
+| #haskell-beginners | A quieter channel for beginner Haskell questions |
+| #haskell-language-server | Haskell lsp based ide |
+| #haskell-web | Friendly, practical discussion of haskell web app/framework/server development |
+| #haskell-docs | The chatroom for coordinating contributions to the documentation |
+| #haskell-infrastructure | Contact [Haskell infrastructure](https://github.com/haskell-infra/haskell-admins) admins |
+| #haskell-game | The hub for Haskell-based game development |
+| #haskell-in-depth | slower paced discussion of use, theory, implementation etc with no monad tutorials! |
+| #haskell-iphone | Haskell-based iPhone development |
+| #haskell-apple | Projects that target iOS or OS X using Haskell. |
+| #haskell-lisp | Haskell Lisp - projects that are creating Lisps written in Haskell, or Haskell implementations written in Lisps. |
+| #haskell-llvm | For projects using Haskell and LLVM |
+| #haskell-overflow | Overflow conversations |
+| #numerical-haskell | For the larger numerical Haskell community |
+| #haskell-blah | Haskell people talking about anything except Haskell itself |
+
+</div>
+
+## Regional and language-specific channels
 
 <div class="table">
 
@@ -39,19 +60,6 @@ Plain text logs for #haskell from before the move to libera.chat (2021) are avai
 | #haskell-se | Swedish speakers |
 | #haskell-tw | Chinese speakers (mainly in Taiwan) |
 | #haskell-vn | Vietnamese speakers |
-| #haskell-beginners | A quieter channel for beginner Haskell questions |
-| #haskell-blah | Haskell people talking about anything except Haskell itself |
-| #haskell-docs | The chatroom for coordinating contributions to the documentation |
-| #haskell-game | The hub for Haskell-based game development |
-| #haskell-in-depth | slower paced discussion of use, theory, implementation etc with no monad tutorials! |
-| #haskell-iphone | Haskell-based iPhone development |
-| #haskell-apple | Projects that target iOS or OS X using Haskell. |
-| #haskell-lisp | Haskell Lisp - projects that are creating Lisps written in Haskell, or Haskell implementations written in Lisps. |
-| #haskell-llvm | For projects using Haskell and LLVM |
-| #haskell-overflow | Overflow conversations |
-| #haskell-web | Friendly, practical discussion of haskell web app/framework/server development |
-| #haskell-language-server | Haskell lsp based ide |
-| #numerical-haskell | For the larger numerical Haskell community |
 
 </div>
 


### PR DESCRIPTION
Perform the following updates to the IRC page:

- Remove mentions of the Freenode -> Libera migration, which was 3 years ago now.

- Demote the link to old Freenode logs; it is no longer important enough to warrant a separate heading.

- Extract regional and language-specific channel list to its own section.

- Reorder the general channel list to prioritise more popular/important topics (according to me).

- Add the `#haskell-infrastructure` channel to the general list.