### PR TITLE
Remove alternative-logo padding

### DIFF
--- a/site/css/hl.css
+++ b/site/css/hl.css
@@ -295,8 +295,7 @@ img {
   height: auto; }
 
 .alternative-logo {
-  filter: drop-shadow(0px 0px 1px black);
-  padding-right: 40px; }
+  filter: drop-shadow(0px 0px 1px black); }
 
 .alternative-logo-visible {
   display: none; }


### PR DESCRIPTION
It causes layout issues on mobile

Before:

 ![image](https://github.com/haskell-infra/www.haskell.org/assets/1667287/cdf56593-8b90-44b4-b782-f5956bf4d244)
 
 
![image](https://github.com/haskell-infra/www.haskell.org/assets/1667287/59cd29f6-78d7-4c3b-88a0-8aa528658aa5)


After:

![image](https://github.com/haskell-infra/www.haskell.org/assets/1667287/9130d044-703c-4992-8171-1b70836a932d)

![image](https://github.com/haskell-infra/www.haskell.org/assets/1667287/7de5100f-d44a-45dc-8e36-92e0e161419a)
