### PR TITLE
Enable alternative logo only when the parameter is present

### DIFF
--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -15,13 +15,6 @@
       <script>
          (function () {
             try {
-              var preferredUwu = false;
-              // localStorage might be inaccessible due to device permissions,
-              // hence the try-catch.
-              try {
-                preferredUwu = localStorage.getItem('uwu');
-              } catch (err) {} ;
-              
               const isUwuValue = window.location 
                 && window.location.search
                 && window.location.search.match(/uwu=(true|false)/);
@@ -29,20 +22,10 @@
               if (isUwuValue) {
                 const isUwu = isUwuValue[1] === 'true';
                 if (isUwu) {
-                  try {
-                    localStorage.setItem('uwu', true);
-                  } catch (err) {} ;
-                  
                   document.documentElement.classList.add('alternative-logo');
                   console.log('alternative logo enabled. turn off with ?uwu=false')
                   console.log('logo credit to @sawaratsuki1004. Slightly tweaked by @Tritlo');
-                } else {
-                  try {
-                    localStorage.removeItem('uwu', false);
-                  } catch (err) {} ;
                 }
-              } else if (preferredUwu) {
-                document.documentElement.classList.add('alternative-logo');
               }
             } catch (err) { }
           })();


### PR DESCRIPTION
The alternative logo persisting causes a bit of surprise from users, and it's difficult to indicate how to turn it off. This removes the persistence, making the alternative logo only available only when the parameter is present.