### PR TITLE
Update LYAH link to a working one

### DIFF
--- a/site/get-started.markdown
+++ b/site/get-started.markdown
@@ -112,7 +112,7 @@ We recommend joining right now, and don't be shy to ask for help! Check [https:/
 Popular free learning resources for beginners:
 
  - [Introductory Haskell course of the University of Pennsylvania (CIS194)](https://www.seas.upenn.edu/~cis1940/spring13/lectures.html) (course)
- - [Learn You a Haskell for Great Good!](http://learnyouahaskell.com/) (book)
+ - [Learn You a Haskell for Great Good!](https://learnyouahaskell.github.io) (book)
  - [Learn Haskell by building a blog generator](https://learn-haskell.blog) (book)
 
 This is just the tip of the iceberg though: check [Documentation](https://www.haskell.org/documentation/) for a bigger list of learning resources. That is it, fellow Haskeller! Enjoy learning Haskell, do (not?) be lazy and see you in the community!


### PR DESCRIPTION
As of recent, https://learnyouahaskell.com/chapters lost any CSS / JS because of hard-coded `<base href="http://learnyouahaskell.com/">` (modern browsers are not keen to leave safety of HTTPS). Let's point to https://learnyouahaskell.github.io, which is a community-maintained fork. Besides working CSS, it is more up to date with modern ecosystem.