### PR TITLE
Add Portland Has Skill meetup

### DIFF
--- a/site/community.markdown
+++ b/site/community.markdown
@@ -45,6 +45,7 @@ There are a number of Haskell Users groups where haskellers meet to learn and co
 *   [Japan Haskell Users Group (Haskell-jp)](http://haskell.jp/)
 *   [New York Haskell Users Group](http://www.meetup.com/NY-Haskell/)
 *   [Munich Haskell Meeting](https://muenchen.haskell.bayern/)
+*   [Portland Has Skill](https://www.meetup.com/portland-has-skill/)
 *   [Seattle Area Haskell Users' Group (SeaHUG)](http://seattlehaskell.org/)
 *   [More Haskell meetups at meetup.com](http://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity)
 


### PR DESCRIPTION
I just founded this meetup and I would like to add it to the community page! 😸

This commit also moves the London Haskell meetup to be in alphabetical order because OCD