### PR TITLE
Remove London Haskell, because it is not longer active

### DIFF
--- a/site/community.markdown
+++ b/site/community.markdown
@@ -45,7 +45,6 @@ There are a number of Haskell Users groups where haskellers meet to learn and co
 *   [Japan Haskell Users Group (Haskell-jp)](http://haskell.jp/)
 *   [New York Haskell Users Group](http://www.meetup.com/NY-Haskell/)
 *   [Munich Haskell Meeting](https://muenchen.haskell.bayern/)
-*   [London Haskell](http://www.meetup.com/London-Haskell/)
 *   [Seattle Area Haskell Users' Group (SeaHUG)](http://seattlehaskell.org/)
 *   [More Haskell meetups at meetup.com](http://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity)
 


### PR DESCRIPTION
This conflicts with https://github.com/haskell-infra/www.haskell.org/pull/301, so when one is merged the other will have to be rebased.