### PR TITLE
Updated info about Haskell.org, Inc.

### DIFF
--- a/site/haskell-org-committee.markdown
+++ b/site/haskell-org-committee.markdown
@@ -5,7 +5,11 @@ page: haskell-org-committee
 
 # Haskell.org
 
-Haskell.org is a 501(c)(3) non-profit organization that oversees the Haskell.org website and a number of other services for the Haskell community:
+Haskell.org, Inc. is a Not-for-Profit Corporation incorporated in the State of
+New York. It is also exempt from taxation under section 501(c)(3) of the US
+Internal Revenue Code of 1986. A committee of Haskell.org, Inc. (the Committee)
+oversees the Haskell.org website and a number of other services for the Haskell
+community:
 
   * [Hackage], Haskell's largest open package repository
   * [GHC] pages and release infrastructure
@@ -14,32 +18,47 @@ Haskell.org is a 501(c)(3) non-profit organization that oversees the Haskell.org
   * [Discourse][discourse]
   * [Hoogle], a type-aware Haskell search engine
 
-Its purpose is to promote educational and scientific progress relating to the Haskell programming language and related technologies.
+The corporation is formed to promote scientific progress and education relating
+to the Haskell programming language and related technologies.
 
+Some particular aspects of the work of the corporation include producing and
+maintaining material regarding the Haskell language on haskell.org and other
+associated websites; hosting and maintaining shared assets and infrastructure
+for the benefit of the Haskell community; coordinating educational activities
+including mentorship programs; and potentially organizing events regarding the
+Haskell language.
 
-Some particular aspects of the work of Haskell.org include producing and maintaining material regarding the Haskell language on haskell.org and other associated websites; hosting and maintaining shared assets and infrastructure for the benefit of the Haskell community; coordinating educational activities including mentorship programs; and potentially organizing event regarding the Haskell language.
-
-Haskell.org also organizes Haskell's participation in  the [Google Summer of Code program][gsoc].
+The corporation also organizes Haskell's participation in the
+[Google Summer of Code program][gsoc].
 
 ### Contact
 
-  * [committee@haskell.org][email]: directly email the committee
-  * [haskell-community mailing list][list]: public discussions about the committee and Haskell community infrastructure
+  * [committee@haskell.org][email]: directly email the Committee
+  * [haskell-community mailing list][list]: public discussions about the
+    Committee and Haskell community infrastructure
   * [GitHub][github]: issues, suggestions and pull requests for the website
   * [Haskell.org proposals][repo]: submit community proposals for Haskell.org
 
+## Haskell.org Bylaws
+
+The bylaws of the corporation are published
+[here](https://gitlab.haskell.org/hf/meta/-/blob/main/bylaws/Bylaws_of_Haskell.org_Inc.md).
+
+The directors of the corporation are also directors of
+[Haskell Foundation, Inc.](https://haskell.foundation/).
 
 ## Haskell.org Committee
 
-The Haskell.org Committee serves as the board of directors for Haskell.org. Its responsibilities include:
+The responsibilities of the Committee include:
 
   * setting the policy for [haskell.org] domain and subdomains
   * setting policy for servers owned or financed by Haskell.org
-  * overseeing Haskell.org donations and funds
+  * overseeing certain Haskell.org donations and funds
 
 ### Committee Membership
 
-The committee consists of 7 members serving 3-year terms. The current members are:
+The committee consists of 7 members serving 3-year terms. The current members
+are:
 
   * Avi Press (term ends 2026)
   * Matthías Páll Gissurarson (term ends 2026)
@@ -49,38 +68,64 @@ The committee consists of 7 members serving 3-year terms. The current members ar
   * Aaron Allen (term ends 2025)
   * Tom Ellis (vice chair, vice treasurer) (term ends 2024)
 
-Committee members do not need to be deep technical Haskell experts.  Instead we look for enthusiasm towards improving the Haskell community.  We aim to represent the different facets of the community.  We aim to be diverse in terms of industry or research, and in terms of gender, race and location.
+Committee members do not need to be deep technical Haskell experts. Instead we
+look for enthusiasm towards improving the Haskell community. We aim to represent
+the different facets of the community. We aim to be diverse in terms of industry
+or research, and in terms of gender, race and location.
 
 ### Process
 
-* The committee's governing rules are laid out in the [Board Resolution](/2015-11-10-Haskell-Org-Board-Resolution.pdf) of that month.
-* The committee uses the [haskell-community mailing list][list] for public discussion, where all interested parties may participate.
+* The Committee follows the governing rules laid out in the corporation's
+  [Board Resolution](/2015-11-10-Haskell-Org-Board-Resolution.pdf) of
+  10 November 2015.
+* The Committee uses the [haskell-community mailing list][list] for public
+  discussion, where all interested parties may participate.
 * Proposals and meeting notes are stored in a [public repository][repo].
-* The committee will seek to reach consensus among its membership on its decisions. Ultimately, the committee will make decisions by more than half of the membership voting for a particular outcome.
+* The Committee will seek to reach consensus among its membership on its
+  decisions. Ultimately, the Committee will make decisions by more than half of
+  the membership voting for a particular outcome.
 * These rules of operation may also be changed in the same way.
 
 #### Committee Membership
 
-The committee consists of 7 members. Members are expected to serve a 3 year term, and terms are staggered so that 2 or 3 members step down each year, at the end of October.
+The Committee consists of 7 members. Members are expected to serve a 3 year
+term, and terms are staggered so that 2 or 3 members step down each year, at the
+end of October.
 
-The members will elect one of their number to be chair each year. The chair is responsible for making sure that things keep moving, and to ensure that a conclusion is reached on any issues raised.
+The members will elect one of their number to be chair each year. The chair is
+responsible for making sure that things keep moving, and to ensure that a
+conclusion is reached on any issues raised.
 
-In November of each year—or if a member steps down before their term is over—the committee holds an open call for new members, encouraging self-nominations. Committee members whose terms are over are eligible for renomination.
+In November of each year—or if a member steps down before their term is over—the
+committee holds an open call for new members, encouraging self-nominations.
+Committee members whose terms are over are eligible for renomination.
 
-After nominations have been solicited, the current committee—including any outgoing members not seeking reelection—selects new members with a simple majority vote.
+After nominations have been solicited, the current Committee—including any
+outgoing members not seeking reelection—selects new members with a simple
+majority vote.
 
-While this has never occurred in the past, Committee members can also be removed by majority vote.
-
+While this has never occurred in the past, Committee members can also be removed
+by majority vote.
 
 ### History
 
-Haskell.org is incorporated in the state of New York as of November 2015.
+The initial Haskell.org committee was
+[formed in November 2010](https://mail.haskell.org/pipermail/haskell/2010-November/022375.html).
+As described there:
 
-The Haskell.org committee was [initially formed in November 2010](https://mail.haskell.org/pipermail/haskell/2010-November/022375.html). As described there:
+> In recent years, haskell.org has started to receive assets, e.g. Google Summer
+Of Code funds, donations for Hackathons, and a Sparc machine for use in GHC
+development. We have also started spending this money: on the community server,
+on a server to take over hosting haskell.org itself, and on the haskell.org
+domain name. There is also interest in running fundraising drives for specific
+things such as Hackathon sponsorship and hosting fees.
 
-> In recent years, haskell.org has started to receive assets, e.g. Google Summer Of Code funds, donations for Hackathons, and a Sparc machine for use in GHC development. We have also started spending this money: on the community server, on a server to take over hosting haskell.org itself, and on the haskell.org domain name. There is also interest in running fundraising drives for specific things such as Hackathon sponsorship and hosting fees.
+> To resolve who is responsible for haskell.org’s infrastructure development,
+open nominations were held to form a haskell.org committee, based on
+representatives from the open source Haskell community.
 
-> To resolve who is responsible for haskell.org’s infrastructure development, open nominations were held to form a haskell.org committee, based on representatives from the open source Haskell community.
+Haskell.org, Inc. was subsequently incorporated on 28 September 2015, with
+DOS ID 4825953.
 
 [discourse]: https://discourse.haskell.org
 [email]: mailto:committee@haskell.org


### PR DESCRIPTION
Given my knowledge as the current Secretary of Haskell.org, Inc., I have suggested some updates to this page for the website Committee to consider, as follows. I have also reformatted existing content to avoid long lines. There are no substantive changes other than those identified in the points below. In particular, I have made no changes to the description of how the Committee itself is constituted or governed.

* For the benefit of non-US readers, I have clarified that '501(c)(3)' is a reference to the US Internal Revenue Code of 1986. I have also distinguished the legal form (New York State Not-for-Profit Corporation) from the US tax status (tax exempt).
* I have used 'the Committee' consistently for the committee (and introduced that term).
* I have used 'the corporation' rather than 'Haskell.org' to distinguish the corporation from the website domain.
* In 'The corporation is formed to ...', I have followed closely the wording as set out in the current bylaws.
* I have provided a link to the current bylaws of the corporation.
* I have included a very brief reference to 'the directors' in addition to the members of the Committee.
* I have corrected the current statement that the members of the Committee all serve as directors of the corporation.
* I have assumed that the Committee does not oversee all donations to the corporation (only 'certain' donations).
* I have reordered the 'history' to be in chronological order.
* As I mention the legal form in the introduction, I do not repeat it in the 'history'.
* I have corrected the date of incorporation, based on the information available at https://apps.dos.ny.gov/publicInquiry/.
* I have added the DOS ID of the corporation.