### PR TITLE
link updates: https, some fixups, remove defunct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Haskell.org Website
 
 This repository holds the source code and content for
-[www.haskell.org](http://www.haskell.org).  Questions about and issues with the site can
+[www.haskell.org](https://www.haskell.org).  Questions about and issues with the site can
 be raised in this repository, and PRs can be made to change
 content. More general administrative issues with the site or related
 haskell.org infrastructure are better [raised directly with the admin
@@ -100,7 +100,7 @@ You may then run the builder binary from the `result` directory:
 
 ### Deploying
 
-The site will automatically be deployed live to <http://www.haskell.org/> every time a branch is merged to `master`. Alternatively an admin for this GitHub repository can deploy the site by visiting the [Deploy workflow page](https://github.com/haskell-infra/www.haskell.org/actions/workflows/deploy.yml), clicking the "Run workflow" dropdown, choosing the branch to build and deploy, and clicking the "Run workflow" button.
+The site will automatically be deployed live to <https://www.haskell.org/> every time a branch is merged to `master`. Alternatively an admin for this GitHub repository can deploy the site by visiting the [Deploy workflow page](https://github.com/haskell-infra/www.haskell.org/actions/workflows/deploy.yml), clicking the "Run workflow" dropdown, choosing the branch to build and deploy, and clicking the "Run workflow" button.
 
 <a id="subsites"></a>
 # Subsites

--- a/site/community.markdown
+++ b/site/community.markdown
@@ -19,11 +19,11 @@ Haskellers are active on a number of online areas, but the most busy are below:
 *   [IRC (online chat)](/irc/)
 *   [Matrix (online chat)](https://matrix.to/#/#haskell:matrix.org)
 *   [Haskell Community Discourse](https://discourse.haskell.org)
-*   [StackOverflow](http://stackoverflow.com/questions/tagged?tagnames=haskell)
+*   [StackOverflow](https://stackoverflow.com/questions/tagged?tagnames=haskell)
 *   [Facebook community](https://www.facebook.com/groups/programming.haskell/)
-*   [Reddit](http://www.reddit.com/r/haskell)
+*   [Reddit](https://www.reddit.com/r/haskell)
 *   [Wiki](https://wiki.haskell.org)
-*   [The blogosphere](http://planet.haskell.org/)
+*   [The blogosphere](https://planet.haskell.org/)
 *   [Haskell Weekly e-mail newsletter](https://haskellweekly.news/)
 *   [Haskell Gitter Community Chat](https://gitter.im/haskell-chat)
 *   [Haskell Communities and Activities Report](https://wiki.haskell.org/Haskell_Communities_and_Activities_Report)
@@ -33,21 +33,21 @@ Haskellers are active on a number of online areas, but the most busy are below:
 
 There are a number of Haskell Users groups where haskellers meet to learn and code. Some are listed below:
 
-*   [Austin Haskell Users Group](http://www.meetup.com/ATX-Haskell/)
-*   [Bay Area Haskell Users Group](http://www.meetup.com/Bay-Area-Haskell-Users-Group/)
-*   [Boston Haskell](http://www.meetup.com/Boston-Haskell/)
-*   [Berlin Haskell Users Group](http://www.meetup.com/berlinhug/)
+*   [Austin Haskell Users Group](https://www.meetup.com/ATX-Haskell/)
+*   [Bay Area Haskell Users Group](https://www.meetup.com/Bay-Area-Haskell-Users-Group/)
+*   [Boston Haskell](https://www.meetup.com/Boston-Haskell/)
+*   [Berlin Haskell Users Group](https://www.meetup.com/berlinhug/)
 *   [Brisbane Functional Programming Group (BFPG)](https://bfpg.org/)
-*   [Chicago Haskell](http://ChicagoHaskell.com/)
+*   [Chicago Haskell](https://www.haskell.social/local/chi/)
 *   [Dublin Haskell Meetup](https://www.meetup.com/haskell-dublin-meetup/)
 *   [Haskell DC](https://www.meetup.com/Haskell-DC/)
-*   [Italy Haskell Users Group](http://www.haskell-ita.it/)
-*   [Japan Haskell Users Group (Haskell-jp)](http://haskell.jp/)
-*   [New York Haskell Users Group](http://www.meetup.com/NY-Haskell/)
+*   [Italy Haskell Users Group](https://www.haskell-ita.it/)
+*   [Japan Haskell Users Group (Haskell-jp)](https://haskell.jp/)
+*   [New York Haskell Users Group](https://www.meetup.com/NY-Haskell/)
 *   [Munich Haskell Meeting](https://muenchen.haskell.bayern/)
 *   [Portland Has Skill](https://www.meetup.com/portland-has-skill/)
-*   [Seattle Area Haskell Users' Group (SeaHUG)](http://seattlehaskell.org/)
-*   [More Haskell meetups at meetup.com](http://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity)
+*   [Seattle Area Haskell Users' Group (SeaHUG)](https://groups.google.com/g/seattlehaskell)
+*   [More Haskell meetups at meetup.com](https://www.meetup.com/find/?allMeetups=true&keywords=Haskell&radius=Infinity)
 
 ## Committees
 
@@ -68,37 +68,36 @@ There are a number of conferences and events featuring Haskell, some focusing on
 
 *   [The Haskell Symposium](https://www.haskell.org/haskell-symposium/)
 *   [Haskell Implementors' Workshop](https://wiki.haskell.org/HaskellImplementorsWorkshop)
-*   [The International Conference on Functional Programming](http://www.icfpconference.org/)
+*   [The International Conference on Functional Programming](https://www.icfpconference.org/)
 *   [Symposium on Principles of Programming Languages](https://www.sigplan.org/Conferences/POPL/)
-*   [International Symposia on Implementation and Application of Functional Languages](http://www.ifl-symposia.org/)
-*   [Symposium on Trends in Functional Programming](http://www.tifp.org/)
+*   [International Symposia on Implementation and Application of Functional Languages](https://ifl-symposia.org/)
+*   [Symposium on Trends in Functional Programming](https://trendsfp.github.io/)
 
 ### Non-Academic Conferences
 
 *   [Commercial Users of Functional Programming (Roving)](http://cufp.org/)
-*   [Functional Conf (Bangalore, IN)](http://functionalconf.com/)
-*   [BOB (Berlin, DE)](http://bobkonf.de/)
-*   [Skills Matter's Haskell eXchange (London, GB)](https://skillsmatter.com/conferences/11741-haskell-exchange-2019)
-*   [LambdaConf (Boulder, CO, USA)](http://lambdaconf.us/)
-*   [Lambda World (Cádiz, Spain and Seattle, USA)](http://www.lambda.world/)
-*   [Compose :: Conference (NY, NY, USA)](http://composeconference.org)
-*   [LambdAle (London, GB)](https://lambdale.org/)
-*   [Haskell Love Conference (online)](https://haskell.love)
+*   [Functional Conf (Bangalore, IN)](https://functionalconf.com/)
+*   [BOB (Berlin, DE)](https://bobkonf.de/)
+*   [LambdaConf (Boulder, CO, USA)](https://www.lambdaconf.us/)
+*   [Lambda Days (Kraków, Poland)](https://www.lambdadays.org/)
+*   [Lambda World (Cádiz, Spain and Seattle, USA)](https://www.lambda.world/)
+*   [Compose :: Conference (NY, NY, USA)](https://www.composeconference.org/)
 
 ### Hackathons
 
 Haskell Hackathons are a long tradition, with lots of learning and social exchange. In many ways they function as semi-structured conferences. Here are some of the most notable:
 
+*   [ZuriHac (Zürich, CH)](https://zurihac.com)
+*   [MuniHac (Munich, DE)](https://munihac.de)
 *   [BayHac (San Francisco Bay Area, CA, USA)](https://wiki.haskell.org/BayHac)
 *   [Hac Phi (Philadelphia, PA, USA)](https://wiki.haskell.org/Hac_Phi)
-*   [ZuriHac (Zurich, CH)](https://wiki.haskell.org/ZuriHac)
 *   [HacFreiburg (Freiburg, De)](https://wiki.haskell.org/HacFreiburg2017)
 
 ## Specific Interest Groups
 
 *   [Industrial Haskell Group](http://industry.haskell.org/)
-*   [Commercial Haskell Group](http://commercialhaskell.com/)
-*   [DataHaskell: data science, machine learning, numerical computation and related](http://www.datahaskell.org/)
+*   [Commercial Haskell Group](https://commercialhaskell.com/)
+*   [DataHaskell: data science, machine learning, numerical computation and related](https://www.datahaskell.org/)
 *   [Haskell Art](https://we.lurk.org/mailman3/lists/haskell-art.we.lurk.org/)
 
 ## Supporting the Community

--- a/site/documentation.markdown
+++ b/site/documentation.markdown
@@ -13,14 +13,14 @@ If you are new to Haskell and are not sure where to start from, we recommend [CI
 ## Introductory Books for Learning Haskell
 
 *   [Learn You a Haskell for Great Good!](https://learnyouahaskell.github.io/)
-*   [Real World Haskell](http://book.realworldhaskell.org/)
+*   [Real World Haskell](https://book.realworldhaskell.org/)
 *   [Learn Haskell by building a blog generator](https://learn-haskell.blog)
 *   \[$$\] [Haskell from the Very Beginning](https://www.haskellfromtheverybeginning.com/)
-*   \[$$\] [Haskell Programming from first principles](http://haskellbook.com)
-*   \[$$\] [Thinking Functionally with Haskell](http://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/thinking-functionally-haskell)
-*   \[$$\] [Programming in Haskell](http://www.cs.nott.ac.uk/~pszgmh/pih.html)
-*   \[$$\] [Haskell: The Craft of Functional Programming](http://www.haskellcraft.com/craft3e/Home.html)
-*   \[$$\] [The Haskell School of Music](http://euterpea.com/haskell-school-of-music/)
+*   \[$$\] [Haskell Programming from first principles](https://haskellbook.com)
+*   \[$$\] [Thinking Functionally with Haskell](https://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/thinking-functionally-haskell)
+*   \[$$\] [Programming in Haskell](https://people.cs.nott.ac.uk/pszgmh/pih.html)
+*   \[$$\] [Haskell: The Craft of Functional Programming](https://www.haskellcraft.com/craft3e/Home.html)
+*   \[$$\] [The Haskell School of Music](https://euterpea.com/haskell-school-of-music/)
 *   \[$$\] [Get Programming with Haskell](https://www.manning.com/books/get-programming-with-haskell)
 *   \[$$\] [Effective Haskell](https://www.pragprog.com/titles/rshaskell/effective-haskell/)
 *   \[$$\] [Haskell: Uma introdução à programação funcional (PT-BR)](https://www.casadocodigo.com.br/products/livro-haskell)
@@ -29,7 +29,7 @@ If you are new to Haskell and are not sure where to start from, we recommend [CI
 
 ## Intermediate Haskell Books
 
-*   [Developing Web Applications with Haskell and Yesod](http://www.yesodweb.com/book)
+*   [Developing Web Applications with Haskell and Yesod](https://www.yesodweb.com/book)
 *   [Parallel and Concurrent Programming in Haskell](https://simonmar.github.io/pages/pcph.html)
 *   \[$$\] [Functional Design and Architecture](https://www.manning.com/books/functional-design-and-architecture)
 *   \[$$\] [Haskell in Depth](https://www.manning.com/books/haskell-in-depth)
@@ -42,12 +42,12 @@ Course material created by instructors
 
 *   [Well-Typed's Introduction to Haskell](https://teaching.well-typed.com/intro/)
 *   [University of Pennsylvania's CIS 194](https://www.seas.upenn.edu/~cis1940/spring13/)
-*   [Data61 Functional Programming Course](https://github.com/data61/fp-course)
-*   [Stanford's cs240h](http://www.scs.stanford.edu/14sp-cs240h/)
+*   [Data61 (NICTA) Functional Programming Course](https://github.com/system-f/fp-course)
+*   [Stanford's cs240h](https://www.scs.stanford.edu/14sp-cs240h/)
 *   [Hendrix's CSCI 360](http://ozark.hendrix.edu/~yorgey/360/f16/)
 *   [University of Helsinki's Haskell MOOC](https://haskell.mooc.fi/)
-*   [University of Nottingham's introductory Haskell course](http://www.cs.nott.ac.uk/~pszgmh/pgp.html)
-*   [University of Nottingham's advanced Haskell course](http://www.cs.nott.ac.uk/~pszgmh/afp.html)
+*   [University of Nottingham's introductory Haskell course](https://people.cs.nott.ac.uk/pszgmh/pgp.html)
+*   [University of Nottingham's advanced Haskell course](https://people.cs.nott.ac.uk/pszgmh/afp.html)
 
 ## Tutorials
 
@@ -55,8 +55,8 @@ Short, dense, classic ways to hit the ground running
 
 *   [A Gentle Introduction to Haskell](https://www.haskell.org/tutorial/)
 *   [Happy Learn Haskell Tutorial](https://www.happylearnhaskelltutorial.com/)
-*   [Yet Another Haskell Tutorial](http://en.wikibooks.org/wiki/Haskell/YAHT/Preamble)
-*   [Write Yourself a Scheme in 48 Hours](http://en.wikibooks.org/wiki/Write_Yourself_a_Scheme_in_48_Hours)
+*   [Yet Another Haskell Tutorial](https://en.wikibooks.org/wiki/Yet_Another_Haskell_Tutorial/Preamble)
+*   [Write Yourself a Scheme in 48 Hours](https://en.wikibooks.org/wiki/Write_Yourself_a_Scheme_in_48_Hours)
 *   [Write Yourself a Scheme 2.0](https://wespiser.com/writings/wyas/home.html)
 *   [Learning Haskell](http://learn.hfm.io)
 *   [Haskell Beginners Course 2022](https://github.com/haskell-beginners-2022/course-plan)
@@ -65,26 +65,26 @@ Short, dense, classic ways to hit the ground running
 
 Curated resources put together by Haskellers:
 
-*   [The Haskell Wiki](http://wiki.haskell.org)
-*   [The Haskell Wikibook](http://en.wikibooks.org/wiki/Haskell)
+*   [The Haskell Wiki](https://wiki.haskell.org)
+*   [The Haskell Wikibook](https://en.wikibooks.org/wiki/Haskell)
 *   [FP Complete's School of Haskell](https://www.schoolofhaskell.com/)
 *   [Stephen Diehl's What I Wish I Knew When Learning Haskell](https://web.archive.org/web/20220513191346/http://dev.stephendiehl.com/hask/)
 *   [Chris Allen's List of Learning Haskell Resources](https://github.com/bitemyapp/learnhaskell)
-*   [Bob Ippolito's Getting Started with Haskell](http://bob.ippoli.to/archives/2013/01/11/getting-started-with-haskell/)
-*   [Albert Y.C. Lai's Haskell Notes and Examples](http://www.vex.net/~trebla/haskell/index.xhtml)
+*   [Bob Ippolito's Getting Started with Haskell](https://bob.ippoli.to/archives/2013/01/11/getting-started-with-haskell/)
+*   [Albert Y.C. Lai's Haskell Notes and Examples](https://www.vex.net/~trebla/haskell/index.xhtml)
 *   [Learning Haskell Resources on the Haskell Wiki](https://wiki.haskell.org/Learning_Haskell)
 
 ## Manuals and Guides
 
 Manuals and guides that cover common Haskell tooling:
 
-*   [GHC User's Guide](http://www.haskell.org/ghc/docs/latest/html/users_guide/)
+*   [GHC User's Guide](https://www.haskell.org/ghc/docs/latest/html/users_guide/)
 *   [Cabal Homepage And Quick Links](https://www.haskell.org/cabal/)
-*   [Cabal User Guide](http://www.haskell.org/cabal/users-guide/)
+*   [Cabal User Guide](https://cabal.readthedocs.io/en/stable/)
 *   [Haskell Language Server](https://haskell-language-server.readthedocs.io/en/stable/)
 *   [Stack User Guide](https://docs.haskellstack.org/)
 *   [Haddock User Guide](https://haskell-haddock.readthedocs.io/)
-*   [Haskeleton: A Haskell Project Skeleton](http://taylor.fausak.me/2014/03/04/haskeleton-a-haskell-project-skeleton/)
+*   [Haskeleton: A Haskell Project Skeleton](https://taylor.fausak.me/2014/03/04/haskeleton-a-haskell-project-skeleton/)
 *   [How to Write a Haskell Program](https://wiki.haskell.org/How_to_write_a_Haskell_program)
 
 ## Package and Dependency Management
@@ -92,19 +92,19 @@ Manuals and guides that cover common Haskell tooling:
 The Cabal guide is a good start but there's a lot to learn:
 
 *   [Stephen Diehl's Cabal Quickstart](https://web.archive.org/web/20220513191346/http://dev.stephendiehl.com/hask/#cabal)
-*   [The Storage and Interpretation of Cabal Packages](http://www.vex.net/~trebla/haskell/sicp.xhtml)
-*   [The Cabal of Cabal](http://www.vex.net/~trebla/haskell/cabal-cabal.xhtml)
+*   [The Storage and Interpretation of Cabal Packages](https://www.vex.net/~trebla/haskell/sicp.xhtml)
+*   [The Cabal of Cabal](https://www.vex.net/~trebla/haskell/cabal-cabal.xhtml)
 
 ## Library Documentation
 
 Documentation for Haskell libraries is typically available on Hackage. We also have specialized tools for searching across it, not only by name, but by type.
 
-*   [Hoogle API Search](http://www.haskell.org/hoogle/)
-*   [Hackage](http://hackage.haskell.org/)
+*   [Hoogle API Search](https://www.haskell.org/hoogle/)
+*   [Hackage](https://hackage.haskell.org/)
 *   [Stackage (with API Search)](https://www.stackage.org)
 *   [The Typeclassopedia](https://wiki.haskell.org/Typeclassopedia)
 *   [Haddocks for Libraries included with GHC](https://downloads.haskell.org/~ghc/latest/docs/html/libraries/index.html)
 
 ## Language Report
 
-The Haskell 2010 language report is available online as [HTML](https://haskell.org/onlinereport/haskell2010/) and as [PDF](https://haskell.org/definition/haskell2010.pdf). The [source is available on GitHub](https://github.com/haskell/haskell-report). The differences between GHC and the report can be found [in the GHC User's Guide](http://www.haskell.org/ghc/docs/latest/html/users_guide/bugs.html#haskell-standards-vs-glasgow-haskell-language-non-compliance).
+The Haskell 2010 language report is available online as [HTML](https://haskell.org/onlinereport/haskell2010/) and as [PDF](https://haskell.org/definition/haskell2010.pdf). The [source is available on GitHub](https://github.com/haskell/haskell-report). The differences between GHC and the report can be found [in the GHC User's Guide](https://www.haskell.org/ghc/docs/latest/html/users_guide/bugs.html#haskell-standards-vs-glasgow-haskell-language-non-compliance).

--- a/site/donations.markdown
+++ b/site/donations.markdown
@@ -24,7 +24,7 @@ A significant part of the Haskell community infrastructure—like Hackage, Hoogl
 
   * Donations through employers via Benevity using the unique ID 475236502
 
-  * Through SPI - Haskell.org is an associated project of Software in the Public Interest, also a registered non-profit organization under the laws of New York State. Donations via the SPI can be made online via credit card, invoice, PO or eCheck through clickandpledge.com or by mailing an earmarked check directly to SPI: http://www.spi-inc.org/donations/. Recurring donations can be set up in addition to one-time donations. Note that donations through SPI require more overhead from the Committee, so we encourage you to use the other ways of donating.
+  * Through SPI - Haskell.org is an associated project of Software in the Public Interest, also a registered non-profit organization under the laws of New York State. Donations via the SPI can be made online via credit card, invoice, PO or eCheck through clickandpledge.com or by mailing an earmarked check directly to SPI: https://www.spi-inc.org/donations/. Recurring donations can be set up in addition to one-time donations. Note that donations through SPI require more overhead from the Committee, so we encourage you to use the other ways of donating.
 
 Haskell.org is a 501(c)(3) non-profit, so donations may be tax-deductible in your jurisdiction.
 

--- a/site/index.html
+++ b/site/index.html
@@ -498,7 +498,7 @@ isHome: true
       </div>
       <div class=" row ">
          <div class=" span6 col-sm-6">
-            <p><strong><a href="http://www.galois.com">Galois</a></strong> provides infrastructure, funds, administrative resources and has historically hosted critical Haskell.org infrastructure, as well as helping the Haskell community at large with their work.</p>
+            <p><strong><a href="https://www.galois.com">Galois</a></strong> provides infrastructure, funds, administrative resources and has historically hosted critical Haskell.org infrastructure, as well as helping the Haskell community at large with their work.</p>
          </div>
         <div class=" span6 col-sm-6">
           <p><strong><a href="https://www.scarf.sh">Scarf</a></strong> provides data and insights on the adoption of Haskell in order to support efforts to grow the Haskell ecosystem and facilitate industry support for the language.</p>

--- a/site/irc.markdown
+++ b/site/irc.markdown
@@ -10,8 +10,6 @@ The IRC channel can be an excellent place to learn more about Haskell, and to ju
 
 Point your IRC client to `irc.libera.chat:6697 (TLS)` and then join the `#haskell` channel (or [connect via your web browser](https://web.libera.chat/#haskell)). Check the [guides](https://libera.chat/guides) for more connection information.
 
-*Plain text logs for `#haskell` from before the move to libera.chat (2021) are available at [tunes](http://tunes.org/~nef/logs/haskell/).*
-
 ## Haskell development and community
 
 <div class="table">

--- a/site/mailing-lists.markdown
+++ b/site/mailing-lists.markdown
@@ -12,9 +12,9 @@ General Haskell questions; extended discussions.
 
 Forum in which it's acceptable to ask anything, no matter how naive, and get polite replies.
 
-[Subscribe now →](http://mail.haskell.org/mailman/listinfo/haskell-cafe)
+[Subscribe now →](https://mail.haskell.org/mailman/listinfo/haskell-cafe)
 
-[Archives](http://mail.haskell.org/pipermail/haskell-cafe/)
+[Archives](https://mail.haskell.org/pipermail/haskell-cafe/)
 
 ## Haskell Announcements
 
@@ -22,27 +22,27 @@ Announcements only.
 
 Intended to be a low-bandwidth list, to which it is safe to subscribe without risking being buried in email. If a thread becomes longer than a handful of messages, please transfer to Haskell-Cafe.
 
-[Subscribe now →](http://mail.haskell.org/mailman/listinfo/haskell)
+[Subscribe now →](https://mail.haskell.org/mailman/listinfo/haskell)
 
-[Archives](http://mail.haskell.org/pipermail/haskell/)
+[Archives](https://mail.haskell.org/pipermail/haskell/)
 
 ## Beginners
 
 Beginner-level, i.e., elementary, Haskell questions and discussions. Any newbie question is welcome.
 
-[Subscribe now →](http://mail.haskell.org/mailman/listinfo/beginners)
+[Subscribe now →](https://mail.haskell.org/mailman/listinfo/beginners)
 
-[Archives](http://mail.haskell.org/pipermail/beginners/)
+[Archives](https://mail.haskell.org/pipermail/beginners/)
 
 ## Haskell Community
 
 Discussions and feedback regarding planned and/or upcoming community-related decisions. Subscribe if you want to be in the know and participate in the decision-making process of the haskell.org committee.
 
-[Subscribe now →](http://mail.haskell.org/cgi-bin/mailman/listinfo/haskell-community)
+[Subscribe now →](https://mail.haskell.org/cgi-bin/mailman/listinfo/haskell-community)
 
 [Archives](https://mail.haskell.org/pipermail/haskell-community/)
 
 ## Other mailing lists
 
-There are many lists hosted on haskell.org, though be warned some are no longer active. The complete list is [here](http://mail.haskell.org).
+There are many lists hosted on haskell.org, though be warned some are no longer active. The complete list is [here](https://mail.haskell.org).
 


### PR DESCRIPTION
- Update a heap of links from http: to https:

- Update a handful of links that were dead, but I found a substitute target.

- Remove a handful of defunct conferences from the Community page

- Promote ZuriHac to top of the Hackathons list

- Remove reference to the pre-libera.chat #haskell IRC logs (target went away, and probably the logs with it).