### PR TITLE
make last example less whitespace sensitive

### DIFF
--- a/site/js/tryhaskell.pages.js
+++ b/site/js/tryhaskell.pages.js
@@ -518,7 +518,7 @@ tryhaskell.pages.list =
             "<code>let abc@(a,b,c) = (10,20,30) in (abc,a,b,c)</code>"
         },
          trigger:function(result){
-             return result.expr.match(/^[ ]*let[ ]*\(_,\(?a:_\)?\)[ ]*=[ ]*\(10,\"abc\"\)[ ]*in[ ]*a[ ]*$/) &&
+            return result.expr.match(/^[ ]*let[ ]*\(_,[ ]*\(?a:_\)?\)[ ]*=[ ]*\(10,[ ]*\"abc\"\)[ ]*in[ ]*a[ ]*$/) &&
                  result.type == "Char";
          }},
         {guide:function(result){


### PR DESCRIPTION
Fixes a little frustration I hit while working through the site's built-in tutorial. Eventually I clicked the spoiler-answer to figure out what I was missing :-)

![whitespace sensitive haskell tutorial](https://github.com/user-attachments/assets/7b86f1d6-2dce-43ba-b011-954ac36ad669)
