### PR TITLE
Create Haskell Package Quality Assurance Tool  Setup

### DIFF
--- a/Haskell Package Quality Assurance Tool  Setup
+++ b/Haskell Package Quality Assurance Tool  Setup
@@ -1,0 +1,68 @@
+
+
+Haskell Package Quality Assurance Tool
+ Setup:
+
+1. Create a new Haskell project:
+   ```bash
+   stack new hackage-quality-tool
+   cd hackage-quality-tool
+   ```
+
+2. Edit the `.cabal` file to include necessary dependencies like `Cabal`, `containers`, `mtl`, 
+
+ 
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Monad (forM_)
+import Data.Text (Text)
+import qualified Data.Text as T
+import System.Directory (listDirectory)
+import System.FilePath ((</>))
+
+-- Function to analyze Haskell files for basic issues
+analyzeHaskellFile :: FilePath -> IO ()
+analyzeHaskellFile filePath = do
+    content <- readFile filePath
+    let linesOfCode = lines content
+    let numLines = length linesOfCode
+    let numComments = length $ filter (T.isPrefixOf "--") (map T.pack linesOfCode)
+    putStrLn $ "File: " ++ filePath
+    putStrLn $ "Lines of Code: " ++ show numLines
+    putStrLn $ "Comment Lines: " ++ show numComments
+    putStrLn ""
+
+-- Function to verify documentation presence
+verifyDocumentation :: FilePath -> IO ()
+verifyDocumentation filePath = do
+    content <- readFile filePath
+    let hasDocs = "-- |" `T.isInfixOf` T.pack content
+    putStrLn $ "Documentation for " ++ filePath ++ ": " ++ show hasDocs
+
+-- Main function to list and analyze Haskell files in a directory
+main :: IO ()
+main = do
+    putStrLn "Analyzing Haskell Packages..."
+    files <- listDirectory "path_to_hackage_packages" -- Update with actual path
+    let haskellFiles = filter (T.isSuffixOf ".hs" . T.pack) files
+    forM_ haskellFiles $ \file -> do
+        let filePath = "path_to_hackage_packages" </> file
+        analyzeHaskellFile filePath
+        verifyDocumentation filePath
+```
+
+ Explanation
+
+- File Analysis: The `analyzeHaskellFile` function reads a Haskell file, counts lines of code, and counts comment lines.
+- Documentation Check: The `verifyDocumentation` function checks for the presence of documentation comments.
+- Directory Listing: The `main` function lists Haskell files in a specified directory and analyzes each file.
+
+Next Steps
+
+1. Expand Analysis: Add more sophisticated static analysis features, like checking for unused imports or type errors.
+2. User Interface: Develop a web interface to allow users to upload packages for analysis.
+3. Reporting: Generate detailed reports based on the analysis results.


### PR DESCRIPTION
Haskell Package Quality Assurance Tool
 Setup:

1. Create a new Haskell project: ```bash stack new hackage-quality-tool cd hackage-quality-tool ```

2. Edit the `.cabal` file to include necessary dependencies like `Cabal`, `containers`, `mtl`, 

 

```haskell
{-# LANGUAGE OverloadedStrings #-}

module Main where

import Control.Monad (forM_)
import Data.Text (Text)
import qualified Data.Text as T
import System.Directory (listDirectory)
import System.FilePath ((</>))

-- Function to analyze Haskell files for basic issues
analyzeHaskellFile :: FilePath -> IO ()
analyzeHaskellFile filePath = do
    content <- readFile filePath
    let linesOfCode = lines content
    let numLines = length linesOfCode
    let numComments = length $ filter (T.isPrefixOf "--") (map T.pack linesOfCode)
    putStrLn $ "File: " ++ filePath
    putStrLn $ "Lines of Code: " ++ show numLines
    putStrLn $ "Comment Lines: " ++ show numComments
    putStrLn ""

-- Function to verify documentation presence
verifyDocumentation :: FilePath -> IO ()
verifyDocumentation filePath = do
    content <- readFile filePath
    let hasDocs = "-- |" `T.isInfixOf` T.pack content
    putStrLn $ "Documentation for " ++ filePath ++ ": " ++ show hasDocs

-- Main function to list and analyze Haskell files in a directory
main :: IO ()
main = do
    putStrLn "Analyzing Haskell Packages..."
    files <- listDirectory "path_to_hackage_packages" -- Update with actual path
    let haskellFiles = filter (T.isSuffixOf ".hs" . T.pack) files
    forM_ haskellFiles $ \file -> do
        let filePath = "path_to_hackage_packages" </> file
        analyzeHaskellFile filePath
        verifyDocumentation filePath
```

 Explanation

- File Analysis: The `analyzeHaskellFile` function reads a Haskell file, counts lines of code, and counts comment lines.
- Documentation Check: The `verifyDocumentation` function checks for the presence of documentation comments.
- Directory Listing: The `main` function lists Haskell files in a specified directory and analyzes each file.

Next Steps

1. Expand Analysis: Add more sophisticated static analysis features, like checking for unused imports or type errors: {-# LANGUAGE OverloadedStrings #-}

module Main where

import Control.Monad (forM_)
import Data.List (isPrefixOf)
import Data.Text (Text)
import qualified Data.Text as T
import System.Directory (listDirectory)
import System.FilePath ((</>))
import Data.Maybe (isJust)

-- Function to analyze Haskell files for basic issues
analyzeHaskellFile :: FilePath -> IO ()
analyzeHaskellFile filePath = do
    content <- readFile filePath
    let linesOfCode = lines content
    let numLines = length linesOfCode
    let numComments = length $ filter (T.isPrefixOf "--") (map T.pack linesOfCode)
    let unusedImports = findUnusedImports content
    putStrLn $ "File: " ++ filePath
    putStrLn $ "Lines of Code: " ++ show numLines
    putStrLn $ "Comment Lines: " ++ show numComments
    putStrLn $ "Unused Imports: " ++ show unusedImports
    putStrLn ""

-- Function to find unused imports
findUnusedImports :: String -> [String]
findUnusedImports content = 
    let imports = filter (isPrefixOf "import") (lines content)
        usedNames = extractUsedNames content
    in [imp | imp <- imports, not (any (`isPrefixOf` imp) usedNames)]

-- Function to extract used names from the code
extractUsedNames :: String -> [String]
extractUsedNames content = 
    let wordsInCode = words content
    in filter (not . null) wordsInCode -- Placeholder for actual extraction logic

-- Function to verify documentation presence
verifyDocumentation :: FilePath -> IO ()
verifyDocumentation filePath = do
    content <- readFile filePath
    let hasDocs = "-- |" `T.isInfixOf` T.pack content
    putStrLn $ "Documentation for " ++ filePath ++ ": " ++ show hasDocs

-- Main function to list and analyze Haskell files in a directory
main :: IO ()
main = do
    putStrLn "Analyzing Haskell Packages..."
    files <- listDirectory "path_to_hackage_packages" -- Update with actual path
    let haskellFiles = filter (T.isSuffixOf ".hs" . T.pack) files
    forM_ haskellFiles $ \file -> do
        let filePath = "path_to_hackage_packages" </> file
        analyzeHaskellFile filePath
        verifyDocumentation filePath
