### PR TITLE
Add "Why Haskell?" benefits section to main page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -116,8 +116,8 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Delightful</h3>
             <p>Software that works, scales and is easy to maintain helps you to attract talent and keep your team motivated.
-               Haskell is a language that lets you express your ideas clearly and teaches you a new way of thinking about programming
-               &mdash; if you work on a challenging project, you might as well have a good time.
+               Haskell is a language that lets you express your ideas clearly and teaches you a new way of thinking about programming&mdash;if
+               you work on a challenging project, you might as well have a good time.
             </p>
          </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -115,7 +115,7 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-md-6">
             <h3>Delightful</h3>
-            <p>Software that works, scales and is easy to maintain helps you to attract talent and keep your team motivated.
+            <p>Software that works, scales, and is easy to maintain helps you to attract talent and keep your team motivated.
                Haskell is a language that lets you express your ideas clearly and teaches you a new way of thinking about programming&mdash;if
                you work on a challenging project, you might as well have a good time.
             </p>

--- a/site/index.html
+++ b/site/index.html
@@ -89,9 +89,9 @@ isHome: true
          </div>
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
-            <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming.
-               It can take advantage of multi-core processors with ease and confidence like few other languages can
-               &mdash; while keeping complexity low as your user base and code base grows.
+            <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming like few other languages can.
+               It can take advantage of multi-core processors with ease thanks to green threads and garbage collection. Additionally, you can use advanced streaming libraries for efficient data processing
+               &mdash; all while keeping complexity low as your user base and code base grow.
             </p>
          </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -90,7 +90,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
             <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming.
-               It can take advantage of multi-core processors with ease and confidence like few other languages can.
+               It can take advantage of multi-core processors with ease and confidence like few other languages can
                &mdash; while keeping complexity low as your user base and code base grows.
             </p>
          </div>
@@ -99,14 +99,14 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Maintain with confidence</h3>
             <p>Add complex features or refactor large parts of your code base reliably. Haskell has one of the strongest type systems on the market to prevent mistakes
-               before they reach production, saving on total software lifetime costs.&mdash;“If it compiles, it works.” and "Fearless refactoring" are common proverbs among Haskellers.
+               before they reach production, saving on total software lifetime costs.&mdash;“If it compiles, it works” and "Fearless refactoring" are common proverbs among Haskellers.
             </p>
          </div>
          <div class=" span6 col-md-6">
-            <h3>Cutting edge</h3>
+            <h3>Bleeding edge</h3>
             <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
-               Try out new programming techniques like Generalized Algebraic Data Types (GADT), Effect Systems, Linear Types and others for even more reliability or performance
-               &mdash; when you're curious or when you want to get ahead.
+               Experiment with new programming techniques like Effect Systems, Linear Types and more related to Dependent Types for even better reliability when you can tolerate some immaturity;
+               or stay with stable best practices&mdash;Haskell supports both.
             </p>
          </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -90,7 +90,8 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
             <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming like few other languages can.
-               It can take advantage of multi-core processors with ease thanks to green threads and garbage collection. Additionally, you can use advanced streaming libraries for efficient data processing
+               It can take advantage of multi-core processors with ease thanks to garbage collection, green threads and immutability everywhere.
+               Additionally, you can use advanced streaming libraries for efficient data processing
                &mdash; all while keeping complexity low as your user base and code base grow.
             </p>
          </div>

--- a/site/index.html
+++ b/site/index.html
@@ -83,38 +83,39 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Rapid prototyping</h3>
             <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
-               to get you started and keep you growing.
+               to get you started and help you growing.
                The strong type system makes it easy to write small and large programs that work, even when you don't like writing types &mdash; the compiler will figure it out.
             </p>
          </div>
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
-            <p>From 1 to 100k users, and more. Haskell can take advantage of multi-core processors with ease and confidence
-               like no mainstream language can, and offers one of the best support for async, concurrent and parallel programming.
+            <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming.
+               It can take advantage of multi-core processors with ease and confidence like no mainstream language can.
+               &mdash; while keeping complexity low as your user base and code base grows.
             </p>
          </div>
       </div>
       <div class=" row ">
          <div class=" span6 col-md-6">
             <h3>Maintain with confidence</h3>
-            <p>Fearless progress and refactoring over the long term. Haskell has one of the strongest type systems on the market to prevent mistakes
-               before they reach production, saving on total software lifetime costs. “If it compiles, it works.”&mdash;a Haskell proverb.
+            <p>Add complex features or refactor large parts of your code base reliably. Haskell has one of the strongest type systems on the market to prevent mistakes
+               before they reach production, saving on total software lifetime costs.&mdash;“If it compiles, it works.” and "Fearless refactoring", some Haskell proverbs.
             </p>
          </div>
          <div class=" span6 col-md-6">
-            <h3>Bleeding edge</h3>
-            <p>Peek into some of the latest programming language innovations. Haskell has its roots in academia and research, and influences many popular languages later on.
-               Stay with safe, current best practices or try out next-generation programming techniques like Generalized Algebraic Data Types (GADT), Effect Systems, Linear Types and more to make your code even more reliable;
-               only when you need it and can tolerate the risk to get ahead: Haskell supports both.
+            <h3>Cutting edge</h3>
+            <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
+               Try out new programming techniques like Generalized Algebraic Data Types (GADT), Effect Systems, Linear Types and others for even more reliability or performance
+               &mdash; when you're curios or when you want to get ahead.
             </p>
          </div>
       </div>
       <div class=" row ">
          <div class=" span6 col-md-6">
-            <h3>Fun</h3>
-            <p>Software that works, scales, is elegant as well as easy to maintain helps to attract talent and keep your team motivated.
-               Haskell is a language that let's you express your ideas clearly and compactly, and teaches you a new way of thinking about programming. 
-               If you work on a challenging project, you might as well have a good time.
+            <h3>Delightful</h3>
+            <p>Software that works, scales and is easy to maintain helps you to attract talent and keep your team motivated.
+               Haskell is a language that let's you express your ideas clearly and teaches you a new way of thinking about programming
+               &mdash; if you work on a challenging project, you might as well have a good time.
             </p>
          </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -101,7 +101,13 @@ isHome: true
                The strong type system makes it easy to write small and large programs that work, even when you don't like writing types &mdash; the compiler will figure it out.
             </p>
          </div>
-        
+         <div class=" span6 col-md-6">
+            <h3>Bleeding edge</h3>
+            <p>Peek into some of the latest programming language innovations. Haskell has its roots in academia and research, and influences many popular languages later on.
+               Stay with safe, current best practices or try out next-generation programming techniques like Generalized Algebraic Data Types (GADT), Effect Systems, Linear Types and more to make your code even more reliable;
+               only when you need it and can tolerate the risk to get ahead: Haskell supports both.
+            </p>
+         </div>
       </div>
    </div>
 </div>

--- a/site/index.html
+++ b/site/index.html
@@ -93,6 +93,16 @@ isHome: true
             </p>
          </div>
       </div>
+      <div class=" row ">
+         <div class=" span6 col-md-6">
+            <h3>Rapid prototyping</h3>
+            <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
+               to get you started and keep you growing.
+               The strong type system makes it easy to write small and large programs that work, even when you don't like writing types &mdash; the compiler will figure it out.
+            </p>
+         </div>
+        
+      </div>
    </div>
 </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -89,7 +89,7 @@ isHome: true
          </div>
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
-            <p>From 1 to 100k users and beyond. Haskell offers best-in-class support for async, concurrent and parallel programming.
+            <p>From one to millions of users and beyond. Haskell offers best-in-class support for async, concurrent, and parallel programming.
                It can take advantage of multi-core processors with ease thanks to garbage collection, green threads and immutability everywhere.
                Additionally, you can use advanced streaming libraries for efficient data processing&mdash;all
                while keeping complexity low as your user base and code base grow.

--- a/site/index.html
+++ b/site/index.html
@@ -83,7 +83,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Rapid prototyping</h3>
             <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
-               to get you started and help you growing.
+               to get you started and help you grow.
                The strong type system makes it easy to write programs that work, both large and small, even when you don't like writing types &mdash; the compiler will figure it out.
             </p>
          </div>

--- a/site/index.html
+++ b/site/index.html
@@ -90,7 +90,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
             <p>From one to millions of users and beyond. Haskell offers best-in-class support for async, concurrent, and parallel programming.
-               It can take advantage of multi-core processors with ease thanks to garbage collection, green threads and immutability everywhere.
+               It can take advantage of multi-core processors with ease thanks to garbage collection, green threads, and immutability everywhere.
                Additionally, you can use advanced streaming libraries for efficient data processing&mdash;all
                while keeping complexity low as your user base and code base grow.
             </p>

--- a/site/index.html
+++ b/site/index.html
@@ -89,7 +89,7 @@ isHome: true
          </div>
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
-            <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming like few other languages can.
+            <p>From 1 to 100k users and beyond. Haskell offers best-in-class support for async, concurrent and parallel programming.
                It can take advantage of multi-core processors with ease thanks to garbage collection, green threads and immutability everywhere.
                Additionally, you can use advanced streaming libraries for efficient data processing
                &mdash; all while keeping complexity low as your user base and code base grow.

--- a/site/index.html
+++ b/site/index.html
@@ -105,7 +105,8 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Bleeding edge</h3>
             <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
-               Experiment with new programming techniques like Effect Systems, Linear Types and more related to Dependent Types for even better reliability when you can tolerate some immaturity;
+               Experiment with new programming techniques like Effect Systems, Functional Reactive Programming (FRP), Linear Types
+               and more related to Dependent Types for even better reliability when you can tolerate some immaturity;
                or stay with stable best practices&mdash;Haskell supports both.
             </p>
          </div>

--- a/site/index.html
+++ b/site/index.html
@@ -106,7 +106,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Bleeding edge</h3>
             <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
-               Experiment with new programming techniques like Effect Systems, Functional Reactive Programming (FRP), Linear Types
+               Experiment with new programming techniques like Effect Systems, Functional Reactive Programming (FRP), Linear Types,
                and Dependent Types;
                or stay with stable best practices&mdash;Haskell supports both.
             </p>

--- a/site/index.html
+++ b/site/index.html
@@ -107,7 +107,7 @@ isHome: true
             <h3>Bleeding edge</h3>
             <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
                Experiment with new programming techniques like Effect Systems, Functional Reactive Programming (FRP), Linear Types
-               and more related to Dependent Types for even better reliability when you can tolerate some immaturity;
+               and Dependent Types;
                or stay with stable best practices&mdash;Haskell supports both.
             </p>
          </div>

--- a/site/index.html
+++ b/site/index.html
@@ -84,7 +84,7 @@ isHome: true
             <h3>Rapid prototyping</h3>
             <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
                to get you started and help you grow.
-               The strong type system makes it easy to write programs that work, both large and small, even when you don't like writing types &mdash; the compiler will figure it out.
+               The strong type system makes it easy to write programs that work, both large and small, even when you don't like writing types&mdash;the compiler will figure it out.
             </p>
          </div>
          <div class=" span6 col-md-6">

--- a/site/index.html
+++ b/site/index.html
@@ -82,7 +82,15 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-md-6">
             <h3>Maintain with confidence</h3>
-            <p>Fearless progress and refactoring over the long term. Haskell has one of the strongest type systems on the market to prevent mistakes before they reach production, saving on total software lifetime costs. “If it compiles, it works.”&mdash;a Haskell proverb.</p>
+            <p>Fearless progress and refactoring over the long term. Haskell has one of the strongest type systems on the market to prevent mistakes
+               before they reach production, saving on total software lifetime costs. “If it compiles, it works.”&mdash;a Haskell proverb.
+            </p>
+         </div>
+         <div class=" span6 col-md-6">
+            <h3>Scale with ease</h3>
+            <p>From 1 to 100k users, and more. Haskell can take advantage of multi-core processors with ease and confidence
+               like no mainstream language can, and offers one of the best support for async, concurrent and parallel programming.
+            </p>
          </div>
       </div>
    </div>

--- a/site/index.html
+++ b/site/index.html
@@ -76,6 +76,18 @@ isHome: true
 
 <br>
 
+<div class="features">
+   <div class=" container ">
+      <h2>Why Haskell?</h2>
+      <div class=" row ">
+         <div class=" span6 col-md-6">
+            <h3>Maintain with confidence</h3>
+            <p>Fearless progress and refactoring over the long term. Haskell has one of the strongest type systems on the market to prevent mistakes before they reach production, saving on total software lifetime costs. “If it compiles, it works.”&mdash;a Haskell proverb.</p>
+         </div>
+      </div>
+   </div>
+</div>
+
 <div id="community-wrapper">
    <div class="videos">
       <div class=" container ">

--- a/site/index.html
+++ b/site/index.html
@@ -109,6 +109,15 @@ isHome: true
             </p>
          </div>
       </div>
+      <div class=" row ">
+         <div class=" span6 col-md-6">
+            <h3>Fun</h3>
+            <p>Software that works, scales, is elegant as well as easy to maintain helps to attract talent and keep your team motivated.
+               Haskell is a language that let's you express your ideas clearly and compactly, and teaches you a new way of thinking about programming. 
+               If you work on a challenging project, you might as well have a good time.
+            </p>
+         </div>
+      </div>
    </div>
 </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -84,13 +84,13 @@ isHome: true
             <h3>Rapid prototyping</h3>
             <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
                to get you started and help you growing.
-               The strong type system makes it easy to write small and large programs that work, even when you don't like writing types &mdash; the compiler will figure it out.
+               The strong type system makes it easy to write programs that work, both large and small, even when you don't like writing types &mdash; the compiler will figure it out.
             </p>
          </div>
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
             <p>From 1 to 100k users, and more. Haskell offers one of the best support for async, concurrent and parallel programming.
-               It can take advantage of multi-core processors with ease and confidence like no mainstream language can.
+               It can take advantage of multi-core processors with ease and confidence like few other languages can.
                &mdash; while keeping complexity low as your user base and code base grows.
             </p>
          </div>
@@ -99,14 +99,14 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Maintain with confidence</h3>
             <p>Add complex features or refactor large parts of your code base reliably. Haskell has one of the strongest type systems on the market to prevent mistakes
-               before they reach production, saving on total software lifetime costs.&mdash;“If it compiles, it works.” and "Fearless refactoring", some Haskell proverbs.
+               before they reach production, saving on total software lifetime costs.&mdash;“If it compiles, it works.” and "Fearless refactoring" are common proverbs among Haskellers.
             </p>
          </div>
          <div class=" span6 col-md-6">
             <h3>Cutting edge</h3>
             <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
                Try out new programming techniques like Generalized Algebraic Data Types (GADT), Effect Systems, Linear Types and others for even more reliability or performance
-               &mdash; when you're curios or when you want to get ahead.
+               &mdash; when you're curious or when you want to get ahead.
             </p>
          </div>
       </div>
@@ -114,7 +114,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Delightful</h3>
             <p>Software that works, scales and is easy to maintain helps you to attract talent and keep your team motivated.
-               Haskell is a language that let's you express your ideas clearly and teaches you a new way of thinking about programming
+               Haskell is a language that lets you express your ideas clearly and teaches you a new way of thinking about programming
                &mdash; if you work on a challenging project, you might as well have a good time.
             </p>
          </div>

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@ isHome: true
             <h3>Delightful</h3>
             <p>Software that works, scales, and is easy to maintain helps you to attract talent and keep your team motivated.
                Haskell is a language that lets you express your ideas clearly and teaches you a new way of thinking about programming&mdash;if
-               you work on a challenging project, you might as well have a good time.
+               you work on a challenging project, you might as well have a good time!
             </p>
          </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -91,8 +91,8 @@ isHome: true
             <h3>Scale with ease</h3>
             <p>From 1 to 100k users and beyond. Haskell offers best-in-class support for async, concurrent and parallel programming.
                It can take advantage of multi-core processors with ease thanks to garbage collection, green threads and immutability everywhere.
-               Additionally, you can use advanced streaming libraries for efficient data processing
-               &mdash; all while keeping complexity low as your user base and code base grow.
+               Additionally, you can use advanced streaming libraries for efficient data processing&mdash;all
+               while keeping complexity low as your user base and code base grow.
             </p>
          </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -81,9 +81,10 @@ isHome: true
       <h2>Why Haskell?</h2>
       <div class=" row ">
          <div class=" span6 col-md-6">
-            <h3>Maintain with confidence</h3>
-            <p>Fearless progress and refactoring over the long term. Haskell has one of the strongest type systems on the market to prevent mistakes
-               before they reach production, saving on total software lifetime costs. “If it compiles, it works.”&mdash;a Haskell proverb.
+            <h3>Rapid prototyping</h3>
+            <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
+               to get you started and keep you growing.
+               The strong type system makes it easy to write small and large programs that work, even when you don't like writing types &mdash; the compiler will figure it out.
             </p>
          </div>
          <div class=" span6 col-md-6">
@@ -95,10 +96,9 @@ isHome: true
       </div>
       <div class=" row ">
          <div class=" span6 col-md-6">
-            <h3>Rapid prototyping</h3>
-            <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
-               to get you started and keep you growing.
-               The strong type system makes it easy to write small and large programs that work, even when you don't like writing types &mdash; the compiler will figure it out.
+            <h3>Maintain with confidence</h3>
+            <p>Fearless progress and refactoring over the long term. Haskell has one of the strongest type systems on the market to prevent mistakes
+               before they reach production, saving on total software lifetime costs. “If it compiles, it works.”&mdash;a Haskell proverb.
             </p>
          </div>
          <div class=" span6 col-md-6">

--- a/site/index.html
+++ b/site/index.html
@@ -82,14 +82,14 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-md-6">
             <h3>Rapid prototyping</h3>
-            <p>Start small and explore new ideas to find your market fit. Haskell is a compact language with a large ecosystem of open-source libraries and tools
+            <p><i>Start small and explore new ideas to find your market fit.</i> Haskell is a compact language with a large ecosystem of open-source libraries and tools
                to get you started and help you grow.
                The strong type system makes it easy to write programs that work, both large and small, even when you don't like writing types&mdash;the compiler will figure it out.
             </p>
          </div>
          <div class=" span6 col-md-6">
             <h3>Scale with ease</h3>
-            <p>From one to millions of users and beyond. Haskell offers best-in-class support for async, concurrent, and parallel programming.
+            <p><i>From one to millions of users and beyond.</i> Haskell offers best-in-class support for async, concurrent, and parallel programming.
                It can take advantage of multi-core processors with ease thanks to garbage collection, green threads, and immutability everywhere.
                Additionally, you can use advanced streaming libraries for efficient data processing&mdash;all
                while keeping complexity low as your user base and code base grow.
@@ -99,13 +99,13 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-md-6">
             <h3>Maintain with confidence</h3>
-            <p>Add complex features or refactor large parts of your code base reliably. Haskell has one of the strongest type systems on the market to prevent mistakes
+            <p><i>Add complex features or refactor large parts of your code base reliably.</i> Haskell has one of the strongest type systems on the market to prevent mistakes
                before they reach production, saving on total software lifetime costs&mdash;“If it compiles, it works” and "Fearless refactoring" are common proverbs among Haskellers.
             </p>
          </div>
          <div class=" span6 col-md-6">
             <h3>Bleeding edge</h3>
-            <p>Get a view into the latest programming innovations. Rooted in programming language research but battled-tested in industry, Haskell has influenced many popular languages and continues to do so.
+            <p><i>Get a view into the latest programming innovations.</i> Rooted in programming language research but battled-tested in industry, Haskell has influenced many popular languages and continues to do so.
                Experiment with new programming techniques like Effect Systems, Functional Reactive Programming (FRP), Linear Types,
                and Dependent Types;
                or stay with stable best practices&mdash;Haskell supports both.
@@ -115,7 +115,7 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-md-6">
             <h3>Delightful</h3>
-            <p>Software that works, scales, and is easy to maintain helps you to attract talent and keep your team motivated.
+            <p><i>Software that works, scales, and is easy to maintain helps you to attract talent and keep your team motivated.</i>
                Haskell is a language that lets you express your ideas clearly and teaches you a new way of thinking about programming&mdash;if
                you work on a challenging project, you might as well have a good time!
             </p>

--- a/site/index.html
+++ b/site/index.html
@@ -100,7 +100,7 @@ isHome: true
          <div class=" span6 col-md-6">
             <h3>Maintain with confidence</h3>
             <p>Add complex features or refactor large parts of your code base reliably. Haskell has one of the strongest type systems on the market to prevent mistakes
-               before they reach production, saving on total software lifetime costs.&mdash;“If it compiles, it works” and "Fearless refactoring" are common proverbs among Haskellers.
+               before they reach production, saving on total software lifetime costs&mdash;“If it compiles, it works” and "Fearless refactoring" are common proverbs among Haskellers.
             </p>
          </div>
          <div class=" span6 col-md-6">

--- a/site/index.html
+++ b/site/index.html
@@ -105,7 +105,7 @@ isHome: true
          </div>
          <div class=" span6 col-md-6">
             <h3>Bleeding edge</h3>
-            <p>Get a view into the latest programming innovations. Haskell has its roots in programming language research, has already influenced many popular languages and continues to do so.
+            <p>Get a view into the latest programming innovations. Rooted in programming language research but battled-tested in industry, Haskell has influenced many popular languages and continues to do so.
                Experiment with new programming techniques like Effect Systems, Functional Reactive Programming (FRP), Linear Types,
                and Dependent Types;
                or stay with stable best practices&mdash;Haskell supports both.


### PR DESCRIPTION
Follow-up from discussions on https://discourse.haskell.org/t/emphasize-why-haskell-on-haskell-org-landing-page/12036

Motivation: Increase general Haskell adoption by focusing on the business/developer benefits in headlines and descriptions, and to reduce technical jargon such that decision makers and developers from other programming languages understand the points easily, and to nudge them to try out Haskell.

Position on landing page:
![image](https://github.com/user-attachments/assets/40bdedfa-e9e5-43c4-a648-67e99bab2e32)

Content:
![image](https://github.com/user-attachments/assets/84b7790a-1b4b-4b43-ba82-b12ef41a9581)

