### PR TITLE
Clarify the site info

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -516,7 +516,7 @@ isHome: true
 
          <div class=" span6 col-sm-6">
             <h3>Psst! Looking for the wiki?</h3>
-            <p>This is the new Haskell home page! The wiki has moved to <a href="https://wiki.haskell.org">wiki.haskell.org.</a></p>
+            <p>This is the new Haskell home page! The wiki has moved to <a href="https://wiki.haskell.org">wiki.haskell.org</a>.</p>
          </div>
       </div>
    </div>

--- a/site/index.html
+++ b/site/index.html
@@ -512,7 +512,9 @@ isHome: true
          <div class=" span6 col-sm-6">
             <h3>Haskell.org</h3>
             Hosted and managed by <a href="haskell-org-committee">Haskell.org</a>, a 501(c)(3) non-profit.
+         </div>
 
+         <div class=" span6 col-sm-6">
             <h3>Psst! Looking for the wiki?</h3>
             <p>This is the new Haskell home page! The wiki has moved to <a href="https://wiki.haskell.org">wiki.haskell.org.</a></p>
          </div>

--- a/site/index.html
+++ b/site/index.html
@@ -510,7 +510,7 @@ isHome: true
    <div class=" container ">
       <div class=" row ">
          <div class=" span6 col-sm-6">
-            <h3>Haskell.org</h3>
+            <h3>Maintenace of this site</h3>
             Hosted and managed by <a href="haskell-org-committee">Haskell.org</a>, a 501(c)(3) non-profit.
          </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -511,7 +511,8 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-sm-6">
             <h3>Maintenace of this site</h3>
-            Hosted and managed by <a href="haskell-org-committee">Haskell.org, Inc.</a>, a 501(c)(3) non-profit.
+	    <!-- &#8288; is "U+2060 Word-Joiner" and preventts a line break being added -->
+            Hosted and managed by <a href="haskell-org-committee">Haskell.org, Inc.</a>, a 501&#8288;(c)&#8288;(3) non-profit.
          </div>
 
          <div class=" span6 col-sm-6">

--- a/site/index.html
+++ b/site/index.html
@@ -511,7 +511,7 @@ isHome: true
       <div class=" row ">
          <div class=" span6 col-sm-6">
             <h3>Maintenace of this site</h3>
-            Hosted and managed by <a href="haskell-org-committee">Haskell.org</a>, a 501(c)(3) non-profit.
+            Hosted and managed by <a href="haskell-org-committee">Haskell.org, Inc.</a>, a 501(c)(3) non-profit.
          </div>
 
          <div class=" span6 col-sm-6">


### PR DESCRIPTION
When @malteneuss was submitting PRs it wasn't clear how to find information about the maintenance of this site: https://discourse.haskell.org/t/emphasize-why-haskell-on-haskell-org-landing-page/12036/35?u=tomjaguarpaw. Hopefully this PR fixes things a bit.

### Before

![screenshot](https://github.com/user-attachments/assets/6cddd9bf-f511-44fc-ab33-c674e54a3788)


### After

![screenshot](https://github.com/user-attachments/assets/df0fab0f-9aad-4ef9-89a4-839e57b5f571)
