### PR TITLE
Add "Why Haskell?" section (alternative)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -76,6 +76,62 @@ isHome: true
 
 <br>
 
+<div class="features">
+   <div class=" container ">
+      <h2>Why Haskell?</h2>
+      <div class=" row ">
+         <div class=" span6 col-md-6">
+            <h3>A new paradigm</h3>
+            <p>Express your ideas clearly and learn a new way of thinking about programming. Based on lambda calculus Haskell is a
+            purely functional programming language that features referential transparency, immutability and lazy evaluation.
+            Concepts that will blow your mind
+               &mdash; relearn programming while having an absolute blast.
+            </p>
+         </div>
+         <div class=" span6 col-md-6">
+            <h3>Composition and predictability</h3>
+            <p>Reason about large pieces of code and compose them easily. There is no global state
+            or mutable variables obscuring the meaning of your program. The strong type system makes sure there are no surprises
+               &mdash; never again will you have to guess what your program does at execution time.
+            </p>
+         </div>
+      </div>
+      <div class=" row ">
+         <div class=" span6 col-md-6">
+           <h3>Declarative</h3>
+           <p>Write your programs declaratively by utilizing the power of pure functions and algebraic data types.
+              In Haskell we don't write how a program should be executed, we just describe its logic
+                 &mdash; never again be forced to think about evaluation order or execution details.
+           </p>
+         </div>
+         <div class=" span6 col-md-6">
+            <h3>Performance</h3>
+            <p>Squeeze out the last ticks of your multi-core processors, thanks to best-in-class support for async,
+            concurrent and parallel programming... made possible via garbage collection and green threads.
+            Use advanced streaming libraries for ultra efficient data processing.
+            </p>
+         </div>
+      </div>
+      <div class=" row ">
+         <div class=" span6 col-md-6">
+            <h3>Abstraction</h3>
+            <p>Build powerful abstractions that are not possible in other languages. Only your imagination is the limit, due to
+            polymorphism, type classes and more advanced typesystem features.
+            Haskell has its roots in programming language research and will always be at the forefront of expressivity.
+            </p>
+         </div>
+         <div class=" span6 col-md-6">
+            <h3>Excellent tooling</h3>
+            <p>A tooling story that's truly amazing: spawn your toolchain with GHCup, build your project with cabal, get editor integration with haskell-language-server
+               &mdash; everything at your fingertips.
+               GHC is the next generation compiler that supports all of your favorite platforms.
+            </p>
+         </div>
+      </div>
+
+   </div>
+</div>
+
 <div id="community-wrapper">
    <div class="videos">
       <div class=" container ">
@@ -519,3 +575,4 @@ isHome: true
       </div>
    </div>
 </div>
+


### PR DESCRIPTION
An alternative to https://github.com/haskell-infra/www.haskell.org/pull/338

The idea is for this to be **developer centric**. We want to attract foremost developers, not managers. And we want to give a glimpse "behind the scenes", connecting the dots between development experience and language features. It's ok if there are words the reader doesn't understand... that's what should make them curious!

Parts of the text are based on the PR by @malteneuss ...other parts were written from scratch.

----

![Screenshot_2025-05-14_01-16-11](https://github.com/user-attachments/assets/ee14dccd-0cbb-482b-8236-1bd5cd1c4785)
