### PR TITLE
Update default.html

### DIFF
--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -5,7 +5,6 @@
       <meta charset="utf-8">
       <meta content="IE edge" http-equiv="X-UA-Compatible">
       <meta content="width=device-width, initial-scale=1" name="viewport">
-      <meta content="haskell,functional,pure,programming,lazy" name="keywords">
       <meta content="The Haskell purely functional programming language home page." name="description">
       <link href="/img/favicon.ico" rel="shortcut icon">
       <link rel="stylesheet" href="/css/fonts.css">


### PR DESCRIPTION
Update based on issue #377

The outdated and obsolete HTML keywords meta tag has been removed.