### PR TITLE
Fill (and refill) the video spots

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -160,6 +160,14 @@ isHome: true
                            </a>
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
+                           <a href="https://www.youtube.com/watch?v=Qa8IfEeBJqk" title="Haskell in 100 Seconds" class="thumbnail">
+                              <img src="https://i1.ytimg.com/vi/Qa8IfEeBJqk/mqdefault.jpg" alt="" class="img-responsive">
+                              <div class="caption">
+                                 <h5>Haskell in 100 Seconds</h5>
+                              </div>
+                           </a>
+                        </div>
+                        <div class=" span3 col-xs-6 col-sm-3 col-md-2">
                            <a href="https://www.youtube.com/watch?v=4RuLzL_q0zs" title="Past and Present of Haskell &ndash; Interview with Simon Peyton Jones" class="thumbnail">
                               <img src="https://i1.ytimg.com/vi/4RuLzL_q0zs/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
@@ -168,10 +176,10 @@ isHome: true
                            </a>
                         </div>
                         <div class=" span3 col-xs-6 col-sm-3 col-md-2">
-                           <a href="https://www.youtube.com/watch?v=t1e8gqXLbsU" title="What is a Monad? by Computerphile / Graham Hutton" class="thumbnail">
-                              <img src="https://i1.ytimg.com/vi/t1e8gqXLbsU/mqdefault.jpg" alt="" class="img-responsive">
+                           <a href="https://www.youtube.com/watch?v=FYTZkE5BZ-0" title="Making Music with Haskell From Scratch" class="thumbnail">
+                              <img src="https://i1.ytimg.com/vi/FYTZkE5BZ-0/mqdefault.jpg" alt="" class="img-responsive">
                               <div class="caption">
-                                 <h5>What is a Monad? by Computerphile / Graham Hutton</h5>
+                                 <h5>Making Music with Haskell From Scratch</h5>
                               </div>
                            </a>
                         </div>


### PR DESCRIPTION
Second round of https://github.com/haskell-infra/www.haskell.org/issues/288, related to https://github.com/haskell-infra/www.haskell.org/issues/373

Reasons to touch the videos:
1) One video was just removed and we had a free spot.
2) When I look at the current list from the lens of Hobbyist vs Academic vs Industry, most (if not all) are leaning towards the "Academic" audience. 

I wanted to add something for Hobbyist and "more mainstream" audience, I have two candidates: [Haskell in 100 Seconds](https://www.youtube.com/watch?v=Qa8IfEeBJqk) and [Making Music with Haskell From Scratch]. I think either could bring some balance to the rest of the videos (I could also see an argument that this makes haskell.org look "less serious")

But I couldn't choose one and also think that "Monad" video doesn't even have Haskell in the title, so I'd suggest swapping it.

---

I also really like these two:
- [The Haskell Unfolder Episode 25: from Java to Haskell](https://www.youtube.com/watch?v=YwshlQXKO80)
- [Developing an application from scratch (Haskell Unfolder #46)
](https://www.youtube.com/watch?v=5W0ZUY_l1dU)

but there are only 6 spots unless someone makes another carousel or something.

---

<img width="998" height="357" alt="Screenshot 2026-06-28 at 4 21 34 PM" src="https://github.com/user-attachments/assets/11053ac2-159e-433c-b126-d72abaf47695" />
