### PR TITLE
Made collapsable elements visible when javascript is disabled

### DIFF
--- a/site/templates/default.html
+++ b/site/templates/default.html
@@ -29,6 +29,17 @@
             } catch (err) { }
           })();
       </script>
+      <noscript>
+        <style>
+          .collapse {
+            display: block;
+          }
+
+          [data-toggle="collapse"] {
+            display: none;
+          }
+        </style>
+      </noscript>
    </head>
    <body class="page-$page$">
      <div class="wrap">


### PR DESCRIPTION
Closes #384

Originally I opted to put all collapsible sections inside `<details>` tags, but it proved difficult to get the animations right for this.

Instead, I think this is a good middle ground. All elements with the `.collapse` class are set to `display: block;`, and all `[data-toggle="collapse"]` elements are set to `display: none;`.

The result is collapsed areas are visible, and the elements that toggle the collapsing behavior are hidden (this might want to be reverted though). The site is a little less pretty to those with JavaScript disabled, though.